### PR TITLE
docs: add --recursive to submodule init command

### DIFF
--- a/docs/hardware/bringup_guide.rst
+++ b/docs/hardware/bringup_guide.rst
@@ -170,7 +170,7 @@ submodules. You can pull down the relevant submodules using ``git``:
 
 .. code:: sh
 
-   $ git submodule update --init
+   $ git submodule update --init --recursive
 
 **Issue: the luna-dev info command doesn't see a connected board.**
 


### PR DESCRIPTION
I think this is required - without it I was missing the sam headers that were in a submodule of tinyusb.