### PR TITLE
Tweak pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 tox
 pyusb
--e git://github.com/nmigen/nmigen.git#egg=nmigen
 -e git://github.com/nmigen/nmigen-soc.git#egg=nmigen-soc
 -e git://github.com/lambdaconcept/minerva.git#egg=minerva
 -e git://github.com/lambdaconcept/lambdasoc.git#egg=lambdasoc


### PR DESCRIPTION
I want to preface this with: I know very little about Python packaging and pip.

I cloned LUNA and followed the getting started instructions. I used requirements.txt as described in the docs. nmigen ~0.3 installed, but then nmigen-soc wanted <0.3, and pip blew up. I took nmigen out of the requirements and let nmigen-soc pull it in as a dependency.