### PR TITLE
gateware.usb2: also enter WAIT_TO_SEND if a packet is about to complete

### DIFF
--- a/luna/gateware/usb/usb2/transfer.py
+++ b/luna/gateware/usb/usb2/transfer.py
@@ -309,7 +309,8 @@ class USBInTransferManager(Elaboratable):
                     # for us in our "write buffer", which we've been filling in the background.
                     # If this is the case, we'll flip which buffer we're working with, toggle our data pid,
                     # and then ready ourselves for transmit.
-                    with m.Elif(~in_stream.ready):
+                    packet_completing = in_stream.valid & (write_fill_count + 1 == self._max_packet_size)
+                    with m.Elif(~in_stream.ready | packet_completing):
                         m.next = "WAIT_TO_SEND"
                         m.d.usb += self.data_pid[0].eq(~self.data_pid[0])
 


### PR DESCRIPTION
This fixes an issue where the IN transfer manager could get stuck in
state WAIT_FOR_DATA if it entered that state just as a packet was
completing.