### PR TITLE
ILA improvements

### DIFF
--- a/luna/gateware/debug/ila.py
+++ b/luna/gateware/debug/ila.py
@@ -13,7 +13,7 @@ import subprocess
 
 from abc             import ABCMeta, abstractmethod
 
-from nmigen          import Signal, Module, Cat, Elaboratable, Memory, ClockDomain, DomainRenamer
+from nmigen          import Signal, Module, Cat, Elaboratable, Memory, ClockDomain, DomainRenamer, Const
 from nmigen.hdl.ast  import Rose
 from nmigen.lib.cdc  import FFSynchronizer
 from vcd             import VCDWriter
@@ -331,6 +331,7 @@ class SyncSerialILA(Elaboratable):
 
         self.bytes_per_sample = words_per_sample * 4
         self.bits_per_sample = self.bytes_per_sample * 8
+        self.padding_bits = self.bits_per_sample - self.ila.sample_width
 
         # Expose our ILA's trigger and status ports directly.
         self.trigger  = self.ila.trigger
@@ -355,7 +356,7 @@ class SyncSerialILA(Elaboratable):
             interface.spi      .connect(self.spi),
 
             # Always output the captured sample.
-            interface.word_out .eq(self.ila.captured_sample)
+            interface.word_out .eq(Cat(self.ila.captured_sample, Const(0, self.padding_bits)))
         ]
 
         # Count where we are in the current transmission.

--- a/luna/gateware/debug/ila.py
+++ b/luna/gateware/debug/ila.py
@@ -330,7 +330,7 @@ class SyncSerialILA(Elaboratable):
         words_per_sample = (self.ila.sample_width + 31) // 32
 
         self.bytes_per_sample = words_per_sample * 4
-        self.bits_per_word = self.bytes_per_sample * 8
+        self.bits_per_sample = self.bytes_per_sample * 8
 
         # Expose our ILA's trigger and status ports directly.
         self.trigger  = self.ila.trigger
@@ -346,7 +346,7 @@ class SyncSerialILA(Elaboratable):
 
         # Connect up our SPI transciever to our public interface.
         interface = SPIDeviceInterface(
-            word_size=self.bits_per_word,
+            word_size=self.bits_per_sample,
             clock_polarity=self.clock_polarity,
             clock_phase=self.clock_phase
         )

--- a/luna/gateware/debug/ila.py
+++ b/luna/gateware/debug/ila.py
@@ -474,7 +474,7 @@ class ILAFrontend(metaclass=ABCMeta):
 
     def _parse_samples(self, raw_samples):
         """ Converts raw, binary samples to dictionaries of name -> sample. """
-        return (self._parse_sample(sample) for sample in raw_samples)
+        return tuple(self._parse_sample(sample) for sample in raw_samples)
 
 
     def refresh(self):

--- a/luna/gateware/debug/ila.py
+++ b/luna/gateware/debug/ila.py
@@ -327,7 +327,7 @@ class SyncSerialILA(Elaboratable):
         # Figure out how many bytes we'll send per sample.
         # We'll always send things squished into 32-bit chunks, as this is what the SPI engine
         # on our Debug Controller likes most.
-        words_per_sample = (self.ila.sample_depth + 31) // 32
+        words_per_sample = (self.ila.sample_width + 31) // 32
 
         self.bytes_per_sample = words_per_sample * 4
         self.bits_per_word = self.bytes_per_sample * 8


### PR DESCRIPTION
Contains the  following changes:
- samples caching in tuple instead of generator (we traverse all of them anyway)
- words_per_sample should be calculated based on sample_width
- small var renaming
- padding to assign all bits in SPI data interface
  We do ignore the irrelevant bits on receive, so I'm not sure how important that is ...
