### PR TITLE
Changed all uses of Rose, Fell, and Past to include which clock domain

### DIFF
--- a/luna/gateware/interface/gateware_phy/phy.py
+++ b/luna/gateware/interface/gateware_phy/phy.py
@@ -207,7 +207,7 @@ class GatewarePHY(Elaboratable):
             ]
 
         # Generate our USB clock strobe, which should pulse at 12MHz.
-        m.d.usb_io += transmitter.i_bit_strobe.eq(Rose(ClockSignal("usb")))
+        m.d.usb_io += transmitter.i_bit_strobe.eq(Rose(ClockSignal("usb"), domain="usb_io"))
 
         #
         # Receiver

--- a/luna/gateware/interface/gateware_phy/receiver.py
+++ b/luna/gateware/interface/gateware_phy/receiver.py
@@ -631,7 +631,7 @@ class RxPipeline(Elaboratable):
         m.d.comb += [
             shifter.reset.eq(detect.o_pkt_end),
             shifter.i_data.eq(bitstuff.o_data),
-            shifter.i_valid.eq(~bitstuff.o_stall & Past(detect.o_pkt_active)),
+            shifter.i_valid.eq(~bitstuff.o_stall & Past(detect.o_pkt_active, domain="usb_io")),
         ]
 
         #

--- a/luna/gateware/interface/spi.py
+++ b/luna/gateware/interface/spi.py
@@ -85,8 +85,8 @@ class SPIDeviceInterface(Elaboratable):
         # Generate the leading and trailing edge detectors.
         # Note that we use rising and falling edge detectors, but call these leading and
         # trailing edges, as our clock here may have been inverted.
-        leading_edge  = Rose(serial_clock)
-        trailing_edge = Fell(serial_clock)
+        leading_edge  = Rose(serial_clock, domain="sync")
+        trailing_edge = Fell(serial_clock, domain="sync")
 
         # Determine the sample and output edges based on the SPI clock phase.
         sample_edge = trailing_edge if self.clock_phase else leading_edge
@@ -336,7 +336,7 @@ class SPICommandInterface(Elaboratable):
         m = Module()
         spi = self.spi
 
-        sample_edge = Fell(spi.sck)
+        sample_edge = Fell(spi.sck, domain="sync")
 
         # Bit counter: counts the number of bits received.
         max_bit_count = max(self.word_size, self.command_size)

--- a/luna/gateware/usb/usb2/endpoint.py
+++ b/luna/gateware/usb/usb2/endpoint.py
@@ -264,7 +264,7 @@ class USBEndpointMultiplexer(Elaboratable):
 
         # We'll connect our PID toggle to whichever interface has a valid transmission going.
         for interface in self._interfaces:
-            with conditional(interface.tx.valid | Past(interface.tx.valid)):
+            with conditional(interface.tx.valid | Past(interface.tx.valid, domain="usb_io")):
                 m.d.comb += shared.tx_pid_toggle.eq(interface.tx_pid_toggle)
 
             conditional = m.Elif


### PR DESCRIPTION
should be used for the history of samples. This avoid a problem where
the main "sync" domain gets used despite a DomainRenamer being used to
move LUNA to a different clock domain.