### PR TITLE
fix typo in USB ILA name

### DIFF
--- a/examples/phy/pipe_phy.py
+++ b/examples/phy/pipe_phy.py
@@ -10,7 +10,7 @@ from nmigen import *
 
 from luna                          import top_level_cli
 from luna.gateware.platform        import NullPin
-from luna.gateware.usb.devices.ila import USBIntegratedLogicAnalyer, USBIntegratedLogicAnalyzerFrontend
+from luna.gateware.usb.devices.ila import USBIntegratedLogicAnalyzer, USBIntegratedLogicAnalyzerFrontend
 
 from luna.gateware.interface.serdes_phy.backends.ecp5 import LunaECP5SerDes
 from luna.gateware.interface.serdes_phy.phy           import SerDesPHY

--- a/examples/phy/serdes_phy.py
+++ b/examples/phy/serdes_phy.py
@@ -10,7 +10,7 @@ from nmigen import *
 
 from luna                          import top_level_cli
 from luna.gateware.platform        import NullPin
-from luna.gateware.usb.devices.ila import USBIntegratedLogicAnalyer, USBIntegratedLogicAnalyzerFrontend
+from luna.gateware.usb.devices.ila import USBIntegratedLogicAnalyzer, USBIntegratedLogicAnalyzerFrontend
 
 from luna.gateware.interface.serdes_phy.backends.ecp5 import LunaECP5SerDes
 from luna.gateware.interface.serdes_phy.phy           import SerDesPHY
@@ -27,7 +27,7 @@ class PIPEPhyExample(Elaboratable):
             self.valid     = Signal()
             self.rx_gpio   = Signal()
 
-            self.ila = USBIntegratedLogicAnalyer(
+            self.ila = USBIntegratedLogicAnalyzer(
                 bus="usb",
                 domain="ss",
                 signals=[

--- a/examples/usb/superspeed/simple_device.py
+++ b/examples/usb/superspeed/simple_device.py
@@ -12,7 +12,7 @@ from usb_protocol.emitters         import SuperSpeedDeviceDescriptorCollection
 
 from luna                          import top_level_cli
 from luna.gateware.platform        import NullPin
-from luna.gateware.usb.devices.ila import USBIntegratedLogicAnalyer, USBIntegratedLogicAnalyzerFrontend
+from luna.gateware.usb.devices.ila import USBIntegratedLogicAnalyzer, USBIntegratedLogicAnalyzerFrontend
 
 from luna.usb3                     import USBSuperSpeedDevice
 

--- a/luna/gateware/usb/devices/ila.py
+++ b/luna/gateware/usb/devices/ila.py
@@ -19,7 +19,7 @@ from usb_protocol.emitters             import DeviceDescriptorCollection
 from usb_protocol.emitters.descriptors import cdc
 
 
-class USBIntegratedLogicAnalyer(Elaboratable):
+class USBIntegratedLogicAnalyzer(Elaboratable):
     """ Pre-made gateware that presents a USB-connected ILA.
 
     Samples are presented over a USB endpoint.


### PR DESCRIPTION
It's the same typo that was fixed in: d67f1ab9e42d5a2034f199fe66fbdc4c47413c7c
then partially reintroduced in: cd40642c74c0a06c20d05474f3698708e3961802 and later.