### PR TITLE
examples/usb/acm_serial does not meet timing requirements on FomuPVT (Max 46.82 MHz)

### DIFF
--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -1,6 +1,8 @@
 name: simulations
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -3,22 +3,25 @@ name: simulations
 on: [push]
 
 jobs:
-  build:
+
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: [3.9]
-
+        py-ver: [3.7, 3.8, 3.9]
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.py-ver }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+        pip install tox
+
+    - run: tox -e py`echo ${{ matrix.py-ver }} | sed 's#\.##g'`

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -25,3 +25,18 @@ jobs:
         pip install tox
 
     - run: tox -e py`echo ${{ matrix.py-ver }} | sed 's#\.##g'`
+
+  fomu:
+    runs-on: ubuntu-latest
+    container: hdlc/impl
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        apt update -qq
+        apt install -y git python3-pip dfu-util
+        python3 -m pip install --upgrade pip
+        pip3 install -r requirements.txt
+        PYTHONPATH=$(pwd) LUNA_PLATFORM=luna.gateware.platform.fomu:FomuPVT python3 examples/usb/acm_serial.py -o fomu.bit

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ pyusb
 -e git://github.com/nmigen/nmigen-soc.git#egg=nmigen-soc
 -e git://github.com/nmigen/nmigen-boards.git#egg=nmigen_boards
 -e git://github.com/lambdaconcept/minerva.git#egg=minerva
--e git://github.com/lambdaconcept/lambdasoc.git#egg=lambdasoc
+#-e git://github.com/lambdaconcept/lambdasoc.git#egg=lambdasoc
 -e git://github.com/usb-tools/python-usb-protocol.git#egg=usb_protocol
--e git://github.com/greatscottgadgets/apollo.git#egg=apollo
+#-e git://github.com/greatscottgadgets/apollo.git#egg=apollo
 pyvcd
 pyserial~=3.4
 libusb1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# Test only under python3.9, for now.
-envlist = py39
+envlist = py{37,38,39}
 skipsdist=True
 
 [testenv]
@@ -30,7 +29,3 @@ commands =
 	python -m luna.gateware.usb.usb3.link.crc
 	python -m luna.gateware.usb.usb3.application.request
 	python -m luna.gateware.memory
-
-[gh-actions]
-python =
-    3.8: py38


### PR DESCRIPTION
Currently, the CI in this repo seems not to be executed. Workflows are triggered, but tox runs no commands. The first commit in this PR is a quick fix for that, which enables tests on py37, py38 and py39.

The second commit shows an issue when trying to build example usb/acm_serial for Fomu (PVT version). Timing is not met, but it's really close:

```
ERROR: Max frequency for clock              'car_clk': 46.82 MHz (FAIL at 48.00 MHz)
```

Was this tested before? Is the example expected to work on Fomu?