### PR TITLE
 Implement Isochronous OUT Endpoint / Add Examples for USB Audio 2 (Audio + MIDI)

### DIFF
--- a/examples/usb/usb2_audio.py
+++ b/examples/usb/usb2_audio.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+from luna.gateware.platform.de0_nano import DE0NanoPlatform
+from nmigen              import Elaboratable, Module
+
+from luna                import top_level_cli
+from luna.usb2           import USBDevice, USBIsochronousInEndpoint, USBIsochronousOutEndpoint
+
+from luna.gateware.stream                        import StreamInterface
+from luna.gateware.usb.usb2.device               import USBDevice
+from luna.gateware.usb.usb2.request              import USBRequestHandler, StallOnlyRequestHandler
+from luna.gateware.usb.usb2.endpoints.stream     import USBStreamInEndpoint, USBStreamOutEndpoint
+
+from usb_protocol.types                import USBRequestType, USBTransferType, USBSynchronizationType, USBUsageType, USBDirection
+from usb_protocol.emitters             import DeviceDescriptorCollection
+from usb_protocol.types.descriptors    import uac
+from usb_protocol.emitters.descriptors import uac2, EndpointDescriptorEmitter
+
+class USB2AudioExample(Elaboratable):
+    """ Demonstrates the use of USB Audio Class v2 """
+    MAX_PACKET_SIZE = 256 * 3 # 256 samples of 24 bit each
+
+    def create_descriptors(self):
+        """ Creates the descriptors that describe our audio topology. """
+
+        descriptors = DeviceDescriptorCollection()
+
+        # Create a device descriptor with our user parameters...
+        # NOTE: This won't work yet, because enumeration stops working
+        # if the configuration descriptor is larger than 64 bytes
+        # which is the case for practically every audio interface
+        # see https://github.com/greatscottgadgets/luna/issues/86
+        with descriptors.DeviceDescriptor() as d:
+            d.bcdUSB             = 2.00
+            d.bDeviceClass       = 0xEF
+            d.bDeviceSubclass    = 0x02
+            d.bDeviceProtocol    = 0x01
+            d.idVendor           = 0x16d0
+            d.idProduct          = 0x0f3b
+
+            d.iManufacturer      = "LUNA"
+            d.iProduct           = "LUNA USB Audio Class 2.0 demo"
+            d.iSerialNumber      = "0815"
+            d.bcdDevice          = 0.01
+
+            d.bNumConfigurations = 1
+
+        with descriptors.ConfigurationDescriptor() as configDescr:
+            # Interface Issociation 
+            interfaceAssociationDescriptor                 = uac2.InterfaceAssociationDescriptorEmitter()
+            interfaceAssociationDescriptor.bInterfaceCount = 3 # Audio Control + Inputs + Outputs
+            configDescr.add_subordinate_descriptor(interfaceAssociationDescriptor)
+
+            # Interface Descriptor (Control)
+            interfaceDescriptor = uac2.StandardAudioControlInterfaceDescriptorEmitter()
+            configDescr.add_subordinate_descriptor(interfaceDescriptor)
+
+            # AudioControl Interface Descriptor
+            audioControlInterface = self.create_audio_control_interface_descriptor()
+            configDescr.add_subordinate_descriptor(audioControlInterface)
+
+            self.create_output_channels_descriptor(configDescr)
+
+            self.create_input_channels_descriptor(configDescr)
+            
+        return descriptors
+
+    def create_audio_control_interface_descriptor(self):
+        audioControlInterface = uac2.ClassSpecificAudioControlInterfaceDescriptorEmitter()
+
+        # AudioControl Interface Descriptor (ClockSource)
+        clockSource = uac2.ClockSourceDescriptorEmitter()
+        clockSource.bClockID     = 1
+        clockSource.bmAttributes = uac2.ClockAttributes.INTERNAL_FIXED_CLOCK
+        clockSource.bmControls   = uac2.ClockFrequencyControl.HOST_READ_ONLY
+        audioControlInterface.add_subordinate_descriptor(clockSource)
+
+        # AudioControl Interface Descriptor (InputTerminal)
+        inputTerminal               = uac2.InputTerminalDescriptorEmitter()
+        inputTerminal.bTerminalID   = 3
+        inputTerminal.wTerminalType = uac.InputTerminalTypes.MICROPHONE
+        inputTerminal.bCSourceID    = 1
+        inputTerminal.bNrChannels   = 1
+        audioControlInterface.add_subordinate_descriptor(inputTerminal)
+
+        # AudioControl Interface Descriptor (OutputTerminal)
+        outputTerminal               = uac2.OutputTerminalDescriptorEmitter()
+        outputTerminal.bTerminalID   = 4
+        outputTerminal.wTerminalType = uac.OutputTerminalTypes.SPEAKER
+        outputTerminal.bSourceID     = 3
+        outputTerminal.bCSourceID    = 1
+        audioControlInterface.add_subordinate_descriptor(outputTerminal)
+
+        return audioControlInterface
+
+    def create_output_channels_descriptor(self, c):
+        #
+        # Interface Descriptor (Streaming, OUT, quiet setting)
+        #
+        quietAudioStreamingInterface                  = uac2.AudioStreamingInterfaceDescriptorEmitter()
+        quietAudioStreamingInterface.bInterfaceNumber = 1
+        c.add_subordinate_descriptor(quietAudioStreamingInterface)
+
+        # Interface Descriptor (Streaming, OUT, active setting)
+        activeAudioStreamingInterface                   = uac2.AudioStreamingInterfaceDescriptorEmitter()
+        activeAudioStreamingInterface.bInterfaceNumber  = 1
+        activeAudioStreamingInterface.bAlternateSetting = 1
+        activeAudioStreamingInterface.bNumEndpoints     = 2
+        c.add_subordinate_descriptor(activeAudioStreamingInterface)
+
+        # AudioStreaming Interface Descriptor (General)
+        audioStreamingInterface               = uac2.ClassSpecificAudioStreamingInterfaceDescriptorEmitter()
+        audioStreamingInterface.bTerminalLink = 4
+        audioStreamingInterface.bFormatType   = uac2.FormatTypes.FORMAT_TYPE_I
+        audioStreamingInterface.bmFormats     = uac2.TypeIFormats.PCM
+        audioStreamingInterface.bNrChannels   = 2
+        c.add_subordinate_descriptor(audioStreamingInterface)
+
+        # AudioStreaming Interface Descriptor (Type I)
+        typeIStreamingInterface  = uac2.TypeIFormatTypeDescriptorEmitter()
+        typeIStreamingInterface.bSubslotSize   = 3  # 24 bit per sample
+        typeIStreamingInterface.bBitResolution = 24 # we use all 24 bits
+        c.add_subordinate_descriptor(typeIStreamingInterface)
+
+        # Endpoint Descriptor (Audio out)
+        audioOutEndpoint = EndpointDescriptorEmitter()
+        audioOutEndpoint.bEndpointAddress     = USBDirection.OUT.to_endpoint_address(1) # EP 1 OUT
+        audioOutEndpoint.bmAttributes         = USBTransferType.ISOCHRONOUS  | \
+                                                USBSynchronizationType.ASYNC | \
+                                                USBUsageType.DATA
+        audioOutEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
+        audioOutEndpoint.bInterval       = 1
+        c.add_subordinate_descriptor(audioOutEndpoint)
+
+        # AudioControl Endpoint Descriptor
+        audioControlEndpoint = uac2.ClassSpecificAudioStreamingIsochronousAudioDataEndpointDescriptorEmitter()
+        c.add_subordinate_descriptor(audioControlEndpoint)
+
+        # Endpoint Descriptor (Feedback IN)
+        feedbackInEndpoint = EndpointDescriptorEmitter()
+        feedbackInEndpoint.bEndpointAddress  = USBDirection.IN.to_endpoint_address(1) # EP 1 IN
+        feedbackInEndpoint.bmAttributes      = USBTransferType.ISOCHRONOUS  | \
+                                               USBSynchronizationType.NONE  | \
+                                               USBUsageType.FEEDBACK
+        feedbackInEndpoint.wMaxPacketSize    = 4
+        feedbackInEndpoint.bInterval         = 4
+        c.add_subordinate_descriptor(feedbackInEndpoint)
+
+    def create_input_channels_descriptor(self, c):
+        #
+        # Interface Descriptor (Streaming, IN, quiet setting)
+        #
+        quietAudioStreamingInterface                  = uac2.AudioStreamingInterfaceDescriptorEmitter()
+        quietAudioStreamingInterface.bInterfaceNumber = 2
+        c.add_subordinate_descriptor(quietAudioStreamingInterface)
+
+        # Interface Descriptor (Streaming, IN, active setting)
+        activeAudioStreamingInterface                   = uac2.AudioStreamingInterfaceDescriptorEmitter()
+        activeAudioStreamingInterface.bInterfaceNumber  = 2
+        activeAudioStreamingInterface.bAlternateSetting = 1
+        activeAudioStreamingInterface.bNumEndpoints     = 1
+        c.add_subordinate_descriptor(activeAudioStreamingInterface)
+
+        # AudioStreaming Interface Descriptor (General)
+        audioStreamingInterface               = uac2.ClassSpecificAudioStreamingInterfaceDescriptorEmitter()
+        audioStreamingInterface.bTerminalLink = 3
+        audioStreamingInterface.bFormatType   = uac2.FormatTypes.FORMAT_TYPE_I
+        audioStreamingInterface.bmFormats     = uac2.TypeIFormats.PCM
+        audioStreamingInterface.bNrChannels   = 1
+        c.add_subordinate_descriptor(audioStreamingInterface)
+
+        # AudioStreaming Interface Descriptor (Type I)
+        typeIStreamingInterface  = uac2.TypeIFormatTypeDescriptorEmitter()
+        typeIStreamingInterface.bSubslotSize   = 3  # 24 bit per sample
+        typeIStreamingInterface.bBitResolution = 24 # we use all 24 bits
+        c.add_subordinate_descriptor(typeIStreamingInterface)
+
+        # Endpoint Descriptor (Audio out)
+        audioOutEndpoint = EndpointDescriptorEmitter()
+        audioOutEndpoint.bEndpointAddress     = USBDirection.IN.to_endpoint_address(2) # EP 2 IN
+        audioOutEndpoint.bmAttributes         = USBTransferType.ISOCHRONOUS  | \
+                                                USBSynchronizationType.ASYNC | \
+                                                USBUsageType.DATA
+        audioOutEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
+        audioOutEndpoint.bInterval       = 1
+        c.add_subordinate_descriptor(audioOutEndpoint)
+
+        # AudioControl Endpoint Descriptor
+        audioControlEndpoint = uac2.ClassSpecificAudioStreamingIsochronousAudioDataEndpointDescriptorEmitter()
+        c.add_subordinate_descriptor(audioControlEndpoint)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # Generate our domain clocks/resets.
+        m.submodules.car = platform.clock_domain_generator()
+
+        # Create our USB-to-serial converter.
+        ulpi = platform.request(platform.default_usb_connection)
+        m.submodules.usb = usb = USBDevice(bus=ulpi)
+
+        # Add our standard control endpoint to the device.
+        descriptors = self.create_descriptors()
+        control_ep = usb.add_standard_control_endpoint(descriptors)
+
+        # Attach our class request handlers.
+        control_ep.add_request_handler(UAC2RequestHandlers())
+
+        # Attach class-request handlers that stall any vendor or reserved requests,
+        # as we don't have or need any.
+        stall_condition = lambda setup : \
+            (setup.type == USBRequestType.VENDOR) | \
+            (setup.type == USBRequestType.RESERVED)
+        control_ep.add_request_handler(StallOnlyRequestHandler(stall_condition))
+
+        ep1_out = USBIsochronousOutEndpoint(
+            endpoint_number=1, # EP 1 OUT
+            max_packet_size=self.MAX_PACKET_SIZE
+        )
+        usb.add_endpoint(ep1_out)
+
+        ep1_in = USBIsochronousInEndpoint(
+            endpoint_number=1, # EP 1 IN
+            max_packet_size=4
+        )
+        usb.add_endpoint(ep1_in)
+
+        ep2_in = USBIsochronousInEndpoint(
+            endpoint_number=2, # EP 2 IN
+            max_packet_size=self.MAX_PACKET_SIZE
+        )
+        usb.add_endpoint(ep2_in)
+
+        # Connect our device as a high speed device
+        m.d.comb += [
+            ep2_in.bytes_in_frame.eq(self.MAX_PACKET_SIZE * 3),
+            ep2_in.value.eq(ep2_in.address),
+            ep1_out.value.eq(ep1_out.address),  
+            usb.connect          .eq(1),
+            usb.full_speed_only  .eq(0),
+        ]
+
+        return m
+
+class UAC2RequestHandlers(USBRequestHandler):
+    """ Minimal set of request handlers to implement UAC2 functionality. """
+
+    def elaborate(self, platform):
+        m = Module()
+
+        interface         = self.interface
+        setup             = self.interface.setup
+
+        #
+        # Class request handlers.
+        #
+
+        with m.If(setup.type == USBRequestType.CLASS):
+            with m.Switch(setup.request):
+                with m.Case(0x10D0): # TODO
+                    pass
+
+                with m.Case():
+                    #
+                    # Stall unhandled requests.
+                    #
+                    with m.If(interface.status_requested | interface.data_requested):
+                        m.d.comb += interface.handshakes_out.stall.eq(1)
+
+                return m
+
+if __name__ == "__main__":
+    e = USB2AudioExample()
+    d = e.create_descriptors()
+    descriptor_bytes = d.get_descriptor_bytes(2)
+    print(f"descriptor length: {len(descriptor_bytes)} bytes: {str(descriptor_bytes.hex())}")
+    top_level_cli(USB2AudioExample)

--- a/examples/usb/usb_midi.py
+++ b/examples/usb/usb_midi.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+from nmigen              import Elaboratable, Module, Cat
+
+from luna                import top_level_cli
+from luna.usb2           import USBDevice, USBStreamInEndpoint, USBStreamOutEndpoint
+
+from luna.gateware.platform                      import NullPin
+from luna.gateware.usb.usb2.request              import StallOnlyRequestHandler
+
+from usb_protocol.types                import USBRequestType, USBDirection
+from usb_protocol.emitters             import DeviceDescriptorCollection
+from usb_protocol.types.descriptors    import uac
+from usb_protocol.emitters.descriptors import uac
+
+class USB2MidiExample(Elaboratable):
+    """ Demonstrates the use of USB MIDI """
+    MAX_PACKET_SIZE = 512
+
+    def create_descriptors(self):
+        """ Creates the descriptors that describe our MIDI topology. """
+
+        descriptors = DeviceDescriptorCollection()
+
+        # Create a device descriptor with our user parameters...
+        with descriptors.DeviceDescriptor() as d:
+            d.bcdUSB             = 2.00
+            d.bDeviceClass       = 0xEF
+            d.bDeviceSubclass    = 0x02
+            d.bDeviceProtocol    = 0x01
+            d.idVendor           = 0x16d0
+            d.idProduct          = 0x0f3b
+
+            d.iManufacturer      = "LUNA"
+            d.iProduct           = "LUNA USB MIDI demo"
+            d.iSerialNumber      = "0815"
+            d.bcdDevice          = 0.01
+
+            d.bNumConfigurations = 1
+
+        with descriptors.ConfigurationDescriptor() as configDescr:
+            interface = uac.StandardMidiStreamingInterfaceDescriptorEmitter()
+            interface.bInterfaceNumber = 0
+            interface.bNumEndpoints = 1 # 2
+            configDescr.add_subordinate_descriptor(interface)
+
+            streamingInterface = uac.ClassSpecificMidiStreamingInterfaceDescriptorEmitter()
+            
+            # prevent the descriptor from getting too large, see https://github.com/greatscottgadgets/luna/issues/86
+            #outToHostJack = uac.MidiOutJackDescriptorEmitter()
+            #outToHostJack.bJackID = 1
+            #outToHostJack.bJackType = uac.MidiStreamingJackTypes.EMBEDDED
+            #outToHostJack.add_source(2)
+            #streamingInterface.add_subordinate_descriptor(outToHostJack)
+#
+            #inToDeviceJack = uac.MidiInJackDescriptorEmitter()
+            #inToDeviceJack.bJackID = 2
+            #inToDeviceJack.bJackType = uac.MidiStreamingJackTypes.EXTERNAL
+            #streamingInterface.add_subordinate_descriptor(inToDeviceJack)
+
+            inFromHostJack = uac.MidiInJackDescriptorEmitter()
+            inFromHostJack.bJackID = 3
+            inFromHostJack.bJackType = uac.MidiStreamingJackTypes.EMBEDDED
+            streamingInterface.add_subordinate_descriptor(inFromHostJack)
+
+            outFromDeviceJack = uac.MidiOutJackDescriptorEmitter()
+            outFromDeviceJack.bJackID = 4
+            outFromDeviceJack.bJackType = uac.MidiStreamingJackTypes.EXTERNAL
+            outFromDeviceJack.add_source(3)
+            streamingInterface.add_subordinate_descriptor(outFromDeviceJack)
+
+            outEndpoint = uac.StandardMidiStreamingBulkDataEndpointDescriptorEmitter()
+            outEndpoint.bEndpointAddress = USBDirection.OUT.to_endpoint_address(1)
+            outEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
+            streamingInterface.add_subordinate_descriptor(outEndpoint)
+
+            outMidiEndpoint = uac.ClassSpecificMidiStreamingBulkDataEndpointDescriptorEmitter()
+            outMidiEndpoint.add_associated_jack(3)
+            streamingInterface.add_subordinate_descriptor(outMidiEndpoint)
+
+            # prevent the descriptor from getting too large, see https://github.com/greatscottgadgets/luna/issues/86
+            #inEndpoint = uac.StandardMidiStreamingDataEndpointDescriptorEmitter()
+            #inEndpoint.bEndpointAddress = USBDirection.IN.from_endpoint_address(1)
+            #inEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
+            #streamingInterface.add_subordinate_descriptor(inEndpoint)
+#
+            #inMidiEndpoint = uac.ClassSpecificMidiStreamingBulkDataEndpointDescriptorEmitter()
+            #inMidiEndpoint.add_associated_jack(1)
+            #streamingInterface.add_subordinate_descriptor(inMidiEndpoint)
+
+            configDescr.add_subordinate_descriptor(streamingInterface)
+            
+        return descriptors
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # Generate our domain clocks/resets.
+        m.submodules.car = platform.clock_domain_generator()
+
+        # Create our USB-to-serial converter.
+        ulpi = platform.request(platform.default_usb_connection)
+        m.submodules.usb = usb = USBDevice(bus=ulpi)
+
+        # Add our standard control endpoint to the device.
+        descriptors = self.create_descriptors()
+        control_ep = usb.add_standard_control_endpoint(descriptors)
+
+        # Attach class-request handlers that stall any vendor or reserved requests,
+        # as we don't have or need any.
+        stall_condition = lambda setup : \
+            (setup.type == USBRequestType.VENDOR) | \
+            (setup.type == USBRequestType.RESERVED)
+        control_ep.add_request_handler(StallOnlyRequestHandler(stall_condition))
+
+        ep1_out = USBStreamOutEndpoint(
+            endpoint_number=1, # EP 1 OUT
+            max_packet_size=self.MAX_PACKET_SIZE
+        )
+        usb.add_endpoint(ep1_out)
+
+        #ep1_in = USBStreamInEndpoint(
+        #    endpoint_number=1, # EP 1 IN
+        #    max_packet_size=self.MAX_PACKET_SIZE
+        #)
+        #usb.add_endpoint(ep1_in)
+
+        leds    = Cat(platform.request_optional("led", i, default=NullPin()) for i in range(6))
+        with m.If(ep1_out.stream.valid):
+            m.d.usb += [
+                leds     .eq(ep1_out.stream.payload),
+            ]
+
+        # Always accept data as it comes in.
+        m.d.comb += ep1_out.stream.ready.eq(1)
+
+        # Connect our device as a high speed device
+        m.d.comb += [
+            usb.connect          .eq(1),
+            usb.full_speed_only  .eq(0),
+        ]
+
+        return m
+
+if __name__ == "__main__":
+    e = USB2MidiExample()
+    d = e.create_descriptors()
+    descriptor_bytes = d.get_descriptor_bytes(2)
+    print(f"descriptor length: {len(descriptor_bytes)} bytes: {str(descriptor_bytes.hex())}")
+    top_level_cli(USB2MidiExample)

--- a/examples/usb/usb_midi.py
+++ b/examples/usb/usb_midi.py
@@ -50,7 +50,7 @@ class USB2MidiExample(Elaboratable):
             configDescr.add_subordinate_descriptor(interface)
 
             streamingInterface = uac.ClassSpecificMidiStreamingInterfaceDescriptorEmitter()
-            
+
             # prevent the descriptor from getting too large, see https://github.com/greatscottgadgets/luna/issues/86
             #outToHostJack = uac.MidiOutJackDescriptorEmitter()
             #outToHostJack.bJackID = 1
@@ -94,7 +94,7 @@ class USB2MidiExample(Elaboratable):
             #streamingInterface.add_subordinate_descriptor(inMidiEndpoint)
 
             configDescr.add_subordinate_descriptor(streamingInterface)
-            
+
         return descriptors
 
     def elaborate(self, platform):
@@ -130,7 +130,7 @@ class USB2MidiExample(Elaboratable):
         #)
         #usb.add_endpoint(ep1_in)
 
-        leds    = Cat(platform.request_optional("led", i, default=NullPin()) for i in range(6))
+        leds    = Cat(platform.request_optional("led", i, default=NullPin()) for i in range(8))
         with m.If(ep1_out.stream.valid):
             m.d.usb += [
                 leds     .eq(ep1_out.stream.payload),

--- a/examples/usb/usb_midi.py
+++ b/examples/usb/usb_midi.py
@@ -51,17 +51,16 @@ class USB2MidiExample(Elaboratable):
 
             streamingInterface = uac.ClassSpecificMidiStreamingInterfaceDescriptorEmitter()
 
-            # prevent the descriptor from getting too large, see https://github.com/greatscottgadgets/luna/issues/86
-            #outToHostJack = uac.MidiOutJackDescriptorEmitter()
-            #outToHostJack.bJackID = 1
-            #outToHostJack.bJackType = uac.MidiStreamingJackTypes.EMBEDDED
-            #outToHostJack.add_source(2)
-            #streamingInterface.add_subordinate_descriptor(outToHostJack)
-#
-            #inToDeviceJack = uac.MidiInJackDescriptorEmitter()
-            #inToDeviceJack.bJackID = 2
-            #inToDeviceJack.bJackType = uac.MidiStreamingJackTypes.EXTERNAL
-            #streamingInterface.add_subordinate_descriptor(inToDeviceJack)
+            outToHostJack = uac.MidiOutJackDescriptorEmitter()
+            outToHostJack.bJackID = 1
+            outToHostJack.bJackType = uac.MidiStreamingJackTypes.EMBEDDED
+            outToHostJack.add_source(2)
+            streamingInterface.add_subordinate_descriptor(outToHostJack)
+
+            inToDeviceJack = uac.MidiInJackDescriptorEmitter()
+            inToDeviceJack.bJackID = 2
+            inToDeviceJack.bJackType = uac.MidiStreamingJackTypes.EXTERNAL
+            streamingInterface.add_subordinate_descriptor(inToDeviceJack)
 
             inFromHostJack = uac.MidiInJackDescriptorEmitter()
             inFromHostJack.bJackID = 3
@@ -83,15 +82,14 @@ class USB2MidiExample(Elaboratable):
             outMidiEndpoint.add_associated_jack(3)
             streamingInterface.add_subordinate_descriptor(outMidiEndpoint)
 
-            # prevent the descriptor from getting too large, see https://github.com/greatscottgadgets/luna/issues/86
-            #inEndpoint = uac.StandardMidiStreamingDataEndpointDescriptorEmitter()
-            #inEndpoint.bEndpointAddress = USBDirection.IN.from_endpoint_address(1)
-            #inEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
-            #streamingInterface.add_subordinate_descriptor(inEndpoint)
-#
-            #inMidiEndpoint = uac.ClassSpecificMidiStreamingBulkDataEndpointDescriptorEmitter()
-            #inMidiEndpoint.add_associated_jack(1)
-            #streamingInterface.add_subordinate_descriptor(inMidiEndpoint)
+            inEndpoint = uac.StandardMidiStreamingDataEndpointDescriptorEmitter()
+            inEndpoint.bEndpointAddress = USBDirection.IN.from_endpoint_address(1)
+            inEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
+            streamingInterface.add_subordinate_descriptor(inEndpoint)
+
+            inMidiEndpoint = uac.ClassSpecificMidiStreamingBulkDataEndpointDescriptorEmitter()
+            inMidiEndpoint.add_associated_jack(1)
+            streamingInterface.add_subordinate_descriptor(inMidiEndpoint)
 
             configDescr.add_subordinate_descriptor(streamingInterface)
 
@@ -124,11 +122,11 @@ class USB2MidiExample(Elaboratable):
         )
         usb.add_endpoint(ep1_out)
 
-        #ep1_in = USBStreamInEndpoint(
-        #    endpoint_number=1, # EP 1 IN
-        #    max_packet_size=self.MAX_PACKET_SIZE
-        #)
-        #usb.add_endpoint(ep1_in)
+        ep1_in = USBStreamInEndpoint(
+            endpoint_number=1, # EP 1 IN
+            max_packet_size=self.MAX_PACKET_SIZE
+        )
+        usb.add_endpoint(ep1_in)
 
         leds    = Cat(platform.request_optional("led", i, default=NullPin()) for i in range(8))
         with m.If(ep1_out.stream.valid):

--- a/luna/gateware/usb/usb2/endpoints/isochronous.py
+++ b/luna/gateware/usb/usb2/endpoints/isochronous.py
@@ -12,7 +12,8 @@ interfaces to hosts via isochronous pipes.
 from nmigen         import Elaboratable, Module, Signal
 
 from ..endpoint     import EndpointInterface
-
+from ...stream      import StreamInterface, USBOutStreamBoundaryDetector
+from ....memory     import TransactionalizedFIFO
 
 class USBIsochronousInEndpoint(Elaboratable):
     """ Isochronous endpoint that presents a memory-like interface.
@@ -213,5 +214,127 @@ class USBIsochronousInEndpoint(Elaboratable):
                     out_stream.last   .eq(1),
                 ]
                 m.next = "IDLE"
+
+        return m
+
+
+class USBIsochronousOutEndpoint(Elaboratable):
+    """ Endpoint interface that receives isochronous data from the host, and produces a simple data stream.
+
+    Used for repeatedly streaming data from a host.
+    Intended to be useful as a transport for e.g. video or audio data.
+
+
+    Attributes
+    ----------
+    stream: StreamInterface, output stream
+        Full-featured stream interface that carries the data we've received from the host.
+        Note that this stream is *transaction* oriented; which means that First and Last indicate
+        the start and end of an individual data packet. This means that short packet detection is
+        the responsibility of the stream's consumer.
+    interface: EndpointInterface
+        Communications link to our USB device.
+
+    Parameters
+    ----------
+    endpoint_number: int
+        The endpoint number (not address) this endpoint should respond to.
+    max_packet_size: int
+        The maximum packet size for this endpoint. If this there isn't either
+        `buffer_size` of, if not given, `max_packet_size * 2` space in
+        the endpoint buffer, this endpoint will silently discard the extraneous data
+    buffer_size: int, optional
+        The total amount of data we'll keep in the buffer; typically three max-packet-sizes or more.
+        Defaults to twice the maximum packet size.
+    """
+
+
+    def __init__(self, *, endpoint_number, max_packet_size, buffer_size=None):
+        self._endpoint_number = endpoint_number
+        self._max_packet_size = max_packet_size
+        self._buffer_size = buffer_size if (buffer_size is not None) else (self._max_packet_size * 2)
+
+        #
+        # I/O port
+        #
+        self.stream    = StreamInterface()
+        self.interface = EndpointInterface()
+
+
+    def elaborate(self, platform):
+        m = Module()
+
+        stream    = self.stream
+        interface = self.interface
+        tokenizer = interface.tokenizer
+
+        #
+        # Internal state.
+        #
+
+        # Stores whether this is the first byte of a transfer. True if the previous byte had its `last` bit set.
+        is_first_byte = Signal(reset=1)
+
+        #
+        # Receiver logic.
+        #
+
+        # Create a version of our receive stream that has added `first` and `last` signals, which we'll use
+        # internally as our main stream.
+        m.submodules.boundary_detector = boundary_detector = USBOutStreamBoundaryDetector()
+        m.d.comb += [
+            interface.rx                   .stream_eq(boundary_detector.unprocessed_stream),
+            boundary_detector.complete_in  .eq(interface.rx_complete),
+            boundary_detector.invalid_in   .eq(interface.rx_invalid),
+        ]
+
+        rx       = boundary_detector.processed_stream
+        rx_first = boundary_detector.first
+        rx_last  = boundary_detector.last
+
+        # Create a Rx FIFO.
+        m.submodules.fifo = fifo = TransactionalizedFIFO(width=10, depth=self._buffer_size, name="rx_fifo", domain="usb")
+
+        # Generate our `first` bit from the most recently transmitted bit.
+        # Essentially, if the most recently valid byte was accompanied by an asserted `last`, the next byte
+        # should have `first` asserted.
+        with m.If(stream.valid & stream.ready):
+            m.d.usb += is_first_byte.eq(stream.last)
+
+        #
+        # Create some basic conditionals that will help us make decisions.
+        #
+
+        endpoint_number_matches  = (tokenizer.endpoint == self._endpoint_number)
+        targeting_endpoint       = endpoint_number_matches & tokenizer.is_out
+        sufficient_space         = (fifo.space_available >= self._max_packet_size)
+        okay_to_receive          = targeting_endpoint & sufficient_space
+
+        m.d.comb += [
+            # We'll always populate our FIFO directly from the receive stream; but we'll also include our
+            # "short packet detected" signal, as this indicates that we're detecting the last byte of a transfer.
+            fifo.write_data[0:8] .eq(rx.payload),
+            fifo.write_data[8]   .eq(rx_last),
+            fifo.write_data[9]   .eq(rx_first),
+            fifo.write_en        .eq(okay_to_receive & rx.next & rx.valid),
+
+            # We'll keep data if our packet finishes with a valid CRC; and discard it otherwise.
+            fifo.write_commit    .eq(targeting_endpoint & boundary_detector.complete_out),
+            fifo.write_discard   .eq(targeting_endpoint & boundary_detector.invalid_out),
+
+            # Our stream data always comes directly out of the FIFO; and is valid
+            # henever our FIFO actually has data for us to read.
+            stream.valid      .eq(~fifo.empty),
+            stream.payload    .eq(fifo.read_data[0:8]),
+
+            # Our `last` bit comes directly from the FIFO; and we know a `first` bit immediately
+            # follows a `last` one.
+            stream.last       .eq(fifo.read_data[8]),
+            stream.first      .eq(fifo.read_data[9]),
+
+            # Move to the next byte in the FIFO whenever our stream is advaced.
+            fifo.read_en      .eq(stream.ready),
+            fifo.read_commit  .eq(1)
+        ]
 
         return m

--- a/luna/usb2.py
+++ b/luna/usb2.py
@@ -13,11 +13,12 @@ from .gateware.usb.usb2.request               import RequestHandlerInterface
 from .gateware.usb.usb2.endpoints.stream      import USBStreamInEndpoint, USBStreamOutEndpoint
 from .gateware.usb.usb2.endpoints.stream      import USBMultibyteStreamInEndpoint
 from .gateware.usb.usb2.endpoints.status      import USBSignalInEndpoint
-from .gateware.usb.usb2.endpoints.isochronous import USBIsochronousInEndpoint
+from .gateware.usb.usb2.endpoints.isochronous import USBIsochronousInEndpoint, USBIsochronousOutEndpoint
 
 __all__ = [
     'USBDevice',
     'EndpointInterface', 'RequestHandlerInterface',
     'USBStreamInEndpoint', 'USBStreamOutEndpoint', 'USBMultibyteStreamInEndpoint',
     'USBSignalInEndpoint',
+    'USBIsochronousInEndpoint', 'USBIsochronousOutEndpoint'
 ]


### PR DESCRIPTION
The MIDI example works if I restrict it to one output only, otherwise the descriptor would get too large
(see https://github.com/greatscottgadgets/luna/issues/86)