### PR TITLE
gateware.stream: Fix multi-byte transfers with StreamSerializer

### DIFF
--- a/luna/gateware/stream/generator.py
+++ b/luna/gateware/stream/generator.py
@@ -625,7 +625,6 @@ class StreamSerializer(Elaboratable):
                     # If there's still data left to transmit, move forward.
                     with m.If(should_continue):
                         m.d.sync += position_in_stream.eq(position_in_stream + 1)
-                        m.d.comb += self.stream.payload.eq(self.data[position_in_stream + 1])
 
                     # Otherwise, we've finished streaming. Return to IDLE.
                     with m.Else():


### PR DESCRIPTION
The removed line made StreamSerializer pick the wrong byte for every transfer except the last, effectively breaking multi-byte transfers. Removing this line solves the problem.

Test case:
```python
m.d.comb += [
    self.transmitter.stream.attach(self.interface.tx),
    self.transmitter.data[0].eq(0x12),
    self.transmitter.data[1].eq(0x34),
    self.transmitter.data[2].eq(0x56),
    self.transmitter.data[3].eq(0x78),
]
```

Before and after:
![image](https://user-images.githubusercontent.com/153099/110951758-b524c500-8345-11eb-93e7-f4e7423f435c.png)
