### PR TITLE
gateware.applets.analyzer: return packet timestamp in microseconds

### DIFF
--- a/luna/gateware/applets/analyzer.py
+++ b/luna/gateware/applets/analyzer.py
@@ -192,6 +192,8 @@ class USBAnalyzerConnection:
             # FIXME: add timeout
             self._device = usb.core.find(idVendor=USB_VENDOR_ID, idProduct=USB_PRODUCT_ID)
 
+        self._start_time = datetime.now()
+
 
     def _fetch_data_into_buffer(self):
         """ Attempts a single data read from the analyzer into our buffer. """
@@ -239,4 +241,5 @@ class USBAnalyzerConnection:
         # ... and return it.
         # TODO: extract and provide status flags
         # TODO: generate a timestamp on-device
-        return packet, datetime.now(), None
+        timestamp_us = (datetime.now() - self._start_time).total_seconds() * 1e6
+        return packet, timestamp_us, None


### PR DESCRIPTION
When trying to run the luna backend in ViewSB, I get this error:

```
$ ./viewsb.sh luna --speed full qt                                                                       
WARNING:root:SoC framework components could not be imported; some functionality will be unavailable.
WARNING:root:No module named 'lambdasoc'
WARNING:root:SoC framework components could not be imported; some functionality will be unavailable.
WARNING:root:No module named 'lambdasoc'
WARNING:root:SoC framework components could not be imported; some functionality will be unavailable.
WARNING:root:No module named 'lambdasoc'
Warning: Wire top.usb.USBControlEndpoint.setup_decoder.data_handler.position_in_packet_TRELLIS_FF_Q_3_DI_LUT4_B_1_Z_TRELLIS_FF_CE_Q has an unprocessed 'init' attribute.
Warning: Wire top.$flatten\usb.\USBControlEndpoint.\setup_decoder.\data_handler.$signal$51 has an unprocessed 'init' attribute.
Warning: Wire top.$flatten\usb.\USBControlEndpoint.\setup_decoder.\data_handler.$signal$52 has an unprocessed 'init' attribute.
Warning: Wire top.$flatten\usb.\USBControlEndpoint.\setup_decoder.\data_handler.$signal$55 has an unprocessed 'init' attribute.
Warning: Wire top.$flatten\usb.\USBControlEndpoint.\setup_decoder.\data_handler.$signal$56 has an unprocessed 'init' attribute.
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/mike/projects/viewsb/viewsb/commands/viewsb.py", line 206, in <module>
    main()
  File "/home/mike/projects/viewsb/viewsb/commands/viewsb.py", line 201, in main
    analyzer.run()
  File "/home/mike/projects/viewsb/viewsb/analyzer.py", line 209, in run
    self.run_analysis_iteration()
  File "/home/mike/projects/viewsb/viewsb/analyzer.py", line 178, in run_analysis_iteration
    self.process_analysis_queue()
  File "/home/mike/projects/viewsb/viewsb/analyzer.py", line 124, in process_analysis_queue
    handled = decoder.handle_packet(packet)
  File "/home/mike/projects/viewsb/viewsb/decoder.py", line 83, in handle_packet
    self.consume_packet(packet)
  File "/home/mike/projects/viewsb/viewsb/decoders/grouping.py", line 456, in consume_packet
    if self.packet_starts_new_transfer(packet) or self.packet_seems_discontinuous(packet):
  File "/home/mike/projects/viewsb/viewsb/decoders/grouping.py", line 442, in packet_seems_discontinuous
    if packet.endpoint_number != 0 and (packet.timestamp - last_packet.timestamp) > 10e3:
TypeError: '>' not supported between instances of 'datetime.timedelta' and 'float'
```

I think the packet timestamp is supposed to be in microseconds, so this change returns that instead of a datetime object.