### PR TITLE
Add blacklist to StandardRequestHandler

### DIFF
--- a/examples/usb/eptri/Makefile
+++ b/examples/usb/eptri/Makefile
@@ -61,4 +61,4 @@ soc.bit: $(SOC) $(TARGET).bin
 
 # Load our SoC onto the FPGA...
 program: soc.bit
-	luna-dev configure soc.bit
+	apollo configure soc.bit

--- a/luna/gateware/stream/generator.py
+++ b/luna/gateware/stream/generator.py
@@ -626,8 +626,7 @@ class StreamSerializer(Elaboratable):
     def __init__(self, data_length, domain="sync", data_width=8, stream_type=StreamInterface, max_length_width=None):
         """
         Parameters:
-            constant_data      -- The constant data for the stream to be generated.
-                                  Should be an array of integers; or, if data_width=8, a bytes-like object.
+            data_length        -- The length of the data to be transmitted.
             domain             -- The clock domain this generator should belong to. Defaults to 'sync'.
             data_width         -- The width of the constant payload
             stream_type        -- The type of stream we'll be multiplexing. Must be a subclass of StreamInterface.

--- a/luna/gateware/usb/request/standard.py
+++ b/luna/gateware/usb/request/standard.py
@@ -6,20 +6,24 @@
 """ Standard, full-gateware control request handlers. """
 
 import os
+import operator
 import unittest
+import functools
+from typing import Iterable, Callable
 
 from luna.gateware.test import utils
 
-from nmigen                 import Module, Elaboratable, Cat
+from nmigen                 import *
+from nmigen.hdl.ast         import Value, Const
 from usb_protocol.types     import USBStandardRequests, USBRequestType
 from usb_protocol.emitters  import DeviceDescriptorCollection
-
 
 from ..usb2.request         import RequestHandlerInterface, USBRequestHandler
 from ..usb2.descriptor      import GetDescriptorHandlerDistributed, GetDescriptorHandlerBlock
 from ..stream               import USBInStreamInterface
 from ...stream.generator    import StreamSerializer
 from luna.gateware.usb.usb2 import descriptor
+from .                      import SetupPacket
 
 
 class StandardRequestHandler(USBRequestHandler):
@@ -31,18 +35,18 @@ class StandardRequestHandler(USBRequestHandler):
         The DeviceDescriptorCollection that contains our descriptors.
     max_packet_size: int, optional
         The maximum packet size for the endpoint associated with this handler.
-
+    blacklist:  iterable of functions that accept a SetupPacket and return a boolean
+        Collection of functions that determine if a given packet will be handled by this request handler.
     avoid_blockram: int, optional
+        If True, placing data into block RAM will be avoided.
 
      """
 
-    def __init__(self, descriptors: DeviceDescriptorCollection, max_packet_size=64, avoid_blockram=None):
-        """
-        Parameters:
-        """
+    def __init__(self, descriptors: DeviceDescriptorCollection, max_packet_size=64, avoid_blockram=None, blacklist: Iterable[Callable[[SetupPacket], Value]] = ()):
         self.descriptors      = descriptors
         self._max_packet_size = max_packet_size
         self._avoid_blockram  = avoid_blockram
+        self._blacklist = blacklist
 
         # If we don't have a value for avoiding blockrams; defer to the environment.
         if self._avoid_blockram is None:
@@ -159,21 +163,25 @@ class StandardRequestHandler(USBRequestHandler):
                     # If we've received a new setup packet, handle it.
                     with m.If(setup.received):
 
-                        # Select which standard packet we're going to handler.
-                        with m.Switch(setup.request):
+                        # Only handle setup packet if not blacklisted
+                        blacklisted = functools.reduce(operator.__or__, (f(setup) for f in self._blacklist), Const(0))
+                        with m.If(~blacklisted):
 
-                            with m.Case(USBStandardRequests.GET_STATUS):
-                                m.next = 'GET_STATUS'
-                            with m.Case(USBStandardRequests.SET_ADDRESS):
-                                m.next = 'SET_ADDRESS'
-                            with m.Case(USBStandardRequests.SET_CONFIGURATION):
-                                m.next = 'SET_CONFIGURATION'
-                            with m.Case(USBStandardRequests.GET_DESCRIPTOR):
-                                m.next = 'GET_DESCRIPTOR'
-                            with m.Case(USBStandardRequests.GET_CONFIGURATION):
-                                m.next = 'GET_CONFIGURATION'
-                            with m.Case():
-                                m.next = 'UNHANDLED'
+                            # Select which standard packet we're going to handler.
+                            with m.Switch(setup.request):
+
+                                with m.Case(USBStandardRequests.GET_STATUS):
+                                    m.next = 'GET_STATUS'
+                                with m.Case(USBStandardRequests.SET_ADDRESS):
+                                    m.next = 'SET_ADDRESS'
+                                with m.Case(USBStandardRequests.SET_CONFIGURATION):
+                                    m.next = 'SET_CONFIGURATION'
+                                with m.Case(USBStandardRequests.GET_DESCRIPTOR):
+                                    m.next = 'GET_DESCRIPTOR'
+                                with m.Case(USBStandardRequests.GET_CONFIGURATION):
+                                    m.next = 'GET_CONFIGURATION'
+                                with m.Case():
+                                    m.next = 'UNHANDLED'
 
 
                 # GET_STATUS -- Fetch the device's status.

--- a/luna/gateware/usb/usb2/control.py
+++ b/luna/gateware/usb/usb2/control.py
@@ -75,16 +75,15 @@ class USBControlEndpoint(Elaboratable):
         self._request_handlers.append(request_handler)
 
 
-    def add_standard_request_handlers(self, descriptors: DeviceDescriptorCollection):
+    def add_standard_request_handlers(self, descriptors: DeviceDescriptorCollection, **kwargs):
         """ Adds a handlers for the standard USB requests.
 
         This will handle all Standard-type requests; so any additional request handlers
         must not handle Standard requests.
 
-        Parameters:
-
+        Parameters will be passed on to StandardRequestHandler.
         """
-        handler = StandardRequestHandler(descriptors, max_packet_size=self._max_packet_size)
+        handler = StandardRequestHandler(descriptors, max_packet_size=self._max_packet_size, **kwargs)
         self._request_handlers.append(handler)
 
 

--- a/luna/gateware/usb/usb2/device.py
+++ b/luna/gateware/usb/usb2/device.py
@@ -174,14 +174,13 @@ class USBDevice(Elaboratable):
         control_endpoint = USBControlEndpoint(utmi=self.utmi)
         self.add_endpoint(control_endpoint)
 
+        return control_endpoint
 
-    def add_standard_control_endpoint(self, descriptors: DeviceDescriptorCollection):
+
+    def add_standard_control_endpoint(self, descriptors: DeviceDescriptorCollection, **kwargs):
         """ Adds a control endpoint with standard request handlers to the device.
 
-        Parameters
-        ----------
-        descriptors: DeviceDescriptorCollection
-            The descriptors to use for this device.
+        Parameters will be passed on to StandardRequestHandler.
 
         Return value
         ------------
@@ -190,7 +189,7 @@ class USBDevice(Elaboratable):
 
         # Create our endpoint, and add standard descriptors to it.
         control_endpoint = USBControlEndpoint(utmi=self.utmi)
-        control_endpoint.add_standard_request_handlers(descriptors)
+        control_endpoint.add_standard_request_handlers(descriptors, **kwargs)
         self.add_endpoint(control_endpoint)
 
         return control_endpoint

--- a/luna/gateware/usb/usb2/interfaces/eptri.py
+++ b/luna/gateware/usb/usb2/interfaces/eptri.py
@@ -542,9 +542,8 @@ class OutFIFOInterface(Peripheral, Elaboratable):
             m.d.usb += self.enable.r_data.eq(self.enable.w_data)
 
         # If we've just ACK'd a receive, clear our enable.
-        with m.If(interface.handshakes_out.ack):
+        with m.If(interface.handshakes_out.ack & token.is_out):
             m.d.usb += self.enable.r_data.eq(0)
-
 
         # Set the value of our endpoint `stall` based on our `stall` register...
         with m.If(self.stall.w_stb):
@@ -575,10 +574,8 @@ class OutFIFOInterface(Peripheral, Elaboratable):
         nak_receive      = nak_receives  & interface.rx_ready_for_response
 
         # Conditions under which we'll ACK or NAK a ping.
-        ack_ping         = ready_to_receive  & token.is_ping & token.new_token
-        nak_ping         = ~ready_to_receive & token.is_ping & token.new_token
-
-
+        ack_ping         = ready_to_receive  & token.is_ping & token.ready_for_response
+        nak_ping         = ~ready_to_receive & token.is_ping & token.ready_for_response
 
         m.d.comb += [
 


### PR DESCRIPTION
Add possibility to pass a blacklist to StandardRequestHandler for packets to ignore, to be able to handle them in a different request handler.