### PR TITLE
Update requirements.txt: apollo is now apollo-fpga

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyusb
 -e git://github.com/lambdaconcept/minerva.git#egg=minerva
 -e git://github.com/lambdaconcept/lambdasoc.git#egg=lambdasoc
 -e git://github.com/usb-tools/python-usb-protocol.git#egg=usb_protocol
--e git://github.com/greatscottgadgets/apollo.git#egg=apollo
+-e git://github.com/greatscottgadgets/apollo.git#egg=apollo-fpga
 pyvcd
 pyserial~=3.4
 libusb1


### PR DESCRIPTION
If you follow the non-recommended route of installing luna without a virtualenv, pip ignores the apollo repo because the module was renamed apollo-egg. This change reflects the new module name.