### PR TITLE
Data returned by handle_simple_data_request() is zero for all bytes beyond the first

### DIFF
--- a/luna/gateware/usb/request/standard.py
+++ b/luna/gateware/usb/request/standard.py
@@ -98,7 +98,7 @@ class StandardRequestHandler(USBRequestHandler):
         # Connect our transmitter up to the output stream...
         m.d.comb += [
             transmitter.stream          .attach(self.interface.tx),
-            Cat(transmitter.data[0:1])  .eq(data),
+            Cat(transmitter.data[0:length]).eq(data),
             transmitter.max_length      .eq(length)
         ]
 


### PR DESCRIPTION
Bug found when implementing GET_STATUS, which returns two bytes.