### PR TITLE
Close ApolloDebugger USB connection after querying device version

### DIFF
--- a/luna/gateware/platform/__init__.py
+++ b/luna/gateware/platform/__init__.py
@@ -92,6 +92,11 @@ def get_appropriate_platform() -> LatticeECP5Platform:
         # only works if we're programming a connected device; otherwise, we'll
         # need to use the custom-platform environment variables.)
         platform.device = debugger.get_fpga_type()
+
+        # Explicitly close the debugger connection, as Windows doesn't allow you to
+        # re-claim the USB device if it's still open.
+        debugger.close()
+
         return platform
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ pyserial = "^3.5"
 pyusb = "^1.1.1"
 pyvcd = "^0.2.4"
 libusb1 = "^1.9.2"
-apollo-fpga = "^0.0.4"
+apollo-fpga = "^0.0.5"
 ziglang = "^0.8.0"
 nmigen = {git = "https://github.com/nmigen/nmigen.git"}
 nmigen-soc = {git = "https://github.com/nmigen/nmigen-soc.git"}


### PR DESCRIPTION
This calls the new close() method on ApolloDebugger to release the USB device after querying the device type. Without explicitly closing the USB device, Windows will not let another instance of ApolloDebugger claim the USB device and actually program the device. This requires merging https://github.com/greatscottgadgets/apollo/pull/6 and publishing version 0.0.5 of apollo-fpga first.