### PR TITLE
Host controlled start/stop of USB analyzer capture

### DIFF
--- a/luna/gateware/applets/analyzer.py
+++ b/luna/gateware/applets/analyzer.py
@@ -292,6 +292,15 @@ class USBAnalyzerConnection:
 
             self._device = usb.core.find(idVendor=USB_VENDOR_ID, idProduct=USB_PRODUCT_ID)
 
+    def start_capture(self):
+        self._device.ctrl_transfer(
+            usb.core.util.CTRL_OUT | usb.core.util.CTRL_TYPE_VENDOR | usb.core.util.CTRL_RECIPIENT_DEVICE,
+            1,
+            1,
+            0,
+            b"",
+            timeout=5,
+        )
 
     def _fetch_data_into_buffer(self):
         """ Attempts a single data read from the analyzer into our buffer. """

--- a/luna/gateware/applets/analyzer.py
+++ b/luna/gateware/applets/analyzer.py
@@ -232,6 +232,9 @@ class USBAnalyzerApplet(Elaboratable):
             # Connect enable signal to host-controlled state register.
             analyzer.capture_enable     .eq(state.current[0]),
 
+            # Flush endpoint when analyzer is idle with capture disabled.
+            stream_ep.flush             .eq(analyzer.idle & ~analyzer.capture_enable),
+
             # USB stream uplink.
             stream_ep.stream            .stream_eq(analyzer.stream),
 

--- a/luna/gateware/applets/analyzer.py
+++ b/luna/gateware/applets/analyzer.py
@@ -229,6 +229,9 @@ class USBAnalyzerApplet(Elaboratable):
         m.submodules.analyzer = analyzer = USBAnalyzer(utmi_interface=utmi)
 
         m.d.comb += [
+            # Connect enable signal to host-controlled state register.
+            analyzer.capture_enable     .eq(state.current[0]),
+
             # USB stream uplink.
             stream_ep.stream            .stream_eq(analyzer.stream),
 

--- a/luna/gateware/usb/analyzer.py
+++ b/luna/gateware/usb/analyzer.py
@@ -72,6 +72,7 @@ class USBAnalyzer(Elaboratable):
         #
         self.stream         = StreamInterface()
 
+        self.capture_enable = Signal()
         self.idle           = Signal()
         self.overrun        = Signal()
         self.capturing      = Signal()
@@ -168,7 +169,7 @@ class USBAnalyzer(Elaboratable):
 
                 # Wait until a transmission is active.
                 # TODO: add triggering logic?
-                with m.If(self.utmi.rx_active):
+                with m.If(self.utmi.rx_active & self.capture_enable):
                     m.next = "CAPTURE"
                     m.d.usb += [
                         header_location  .eq(write_location),

--- a/luna/gateware/usb/analyzer.py
+++ b/luna/gateware/usb/analyzer.py
@@ -279,7 +279,8 @@ class USBAnalyzerTest(LunaGatewareTestCase):
             ('rx_error',    1),
             ('rx_complete', 1),
         ])
-        return USBAnalyzer(utmi_interface=self.utmi, mem_depth=128)
+        self.analyzer = USBAnalyzer(utmi_interface=self.utmi, mem_depth=128)
+        return self.analyzer
 
 
     def advance_stream(self, value):
@@ -289,6 +290,9 @@ class USBAnalyzerTest(LunaGatewareTestCase):
 
     @usb_domain_test_case
     def test_single_packet(self):
+        # Enable capture
+        yield self.analyzer.capture_enable.eq(1)
+        yield
 
         # Ensure we're not capturing until a transaction starts.
         self.assertEqual((yield self.dut.capturing), 0)
@@ -338,6 +342,9 @@ class USBAnalyzerTest(LunaGatewareTestCase):
 
     @usb_domain_test_case
     def test_short_packet(self):
+        # Enable capture
+        yield self.analyzer.capture_enable.eq(1)
+        yield
 
         # Apply our first input, and validate that we start capturing.
         yield self.utmi.rx_active.eq(1)
@@ -421,6 +428,8 @@ class USBAnalyzerStackTest(LunaGatewareTestCase):
 
     @usb_domain_test_case
     def test_simple_analysis(self):
+        # Enable capture
+        yield self.analyzer.capture_enable.eq(1)
         yield from self.advance_cycles(10)
 
         # Start a new packet.

--- a/luna/gateware/usb/request/control.py
+++ b/luna/gateware/usb/request/control.py
@@ -1,0 +1,77 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+""" Full-gateware control request handlers. """
+
+import unittest
+
+from amaranth               import *
+
+from ..usb2.request         import USBRequestHandler
+
+
+class ControlRequestHandler(USBRequestHandler):
+    """ Pure-gateware USB control request handler. """
+
+
+    def handle_register_write_request(self, m, new_value_signal, write_strobe, stall_condition=0):
+        """ Fills in the current state with a request handler meant to set a register.
+
+        Parameters:
+            new_value_signal -- The signal to receive the new value to be applied to the relevant register.
+            write_strobe     -- The signal which will be pulsed when new_value_signal contains a update.
+            stall_condition  -- If provided, if this condition is true, the request will be STALL'd instead
+                                of acknowledged.
+            """
+
+        # Provide an response to the STATUS stage.
+        with m.If(self.interface.status_requested):
+
+            # If our stall condition is met, stall; otherwise, send a ZLP [USB 8.5.3].
+            with m.If(stall_condition):
+                m.d.comb += self.interface.handshakes_out.stall.eq(1)
+            with m.Else():
+                m.d.comb += self.send_zlp()
+
+        # Accept the relevant value after the packet is ACK'd...
+        with m.If(self.interface.handshakes_in.ack):
+            m.d.comb += [
+                write_strobe      .eq(1),
+                new_value_signal  .eq(self.interface.setup.value[0:7])
+            ]
+
+            # ... and then return to idle.
+            m.next = 'IDLE'
+
+
+    def handle_simple_data_request(self, m, transmitter, data, length=1):
+        """ Fills in a given current state with a request that returns a given piece of data.
+
+        For e.g. GET_CONFIGURATION and GET_STATUS requests.
+
+        Parameters:
+            transmitter -- The transmitter module we're working with.
+            data        -- The data to be returned.
+        """
+
+        # Connect our transmitter up to the output stream...
+        m.d.comb += [
+            transmitter.stream          .attach(self.interface.tx),
+            Cat(transmitter.data[0:length]).eq(data),
+            transmitter.max_length      .eq(length)
+        ]
+
+        # ... trigger it to respond when data's requested...
+        with m.If(self.interface.data_requested):
+            m.d.comb += transmitter.start.eq(1)
+
+        # ... and ACK our status stage.
+        with m.If(self.interface.status_requested):
+            m.d.comb += self.interface.handshakes_out.ack.eq(1)
+            m.next = 'IDLE'
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")

--- a/luna/gateware/usb/request/standard.py
+++ b/luna/gateware/usb/request/standard.py
@@ -24,9 +24,10 @@ from ..stream               import USBInStreamInterface
 from ...stream.generator    import StreamSerializer
 from luna.gateware.usb.usb2 import descriptor
 from .                      import SetupPacket
+from .control               import ControlRequestHandler
 
 
-class StandardRequestHandler(USBRequestHandler):
+class StandardRequestHandler(ControlRequestHandler):
     """ Pure-gateware USB setup request handler. Implements the standard requests required for enumeration.
 
     Parameters
@@ -53,64 +54,6 @@ class StandardRequestHandler(USBRequestHandler):
             self._avoid_blockram = os.getenv("LUNA_AVOID_BLOCKRAM", False)
 
         super().__init__()
-
-
-    def handle_register_write_request(self, m, new_value_signal, write_strobe, stall_condition=0):
-        """ Fills in the current state with a request handler meant to set a register.
-
-        Parameters:
-            new_value_signal -- The signal to receive the new value to be applied to the relevant register.
-            write_strobe     -- The signal which will be pulsed when new_value_signal contains a update.
-            stall_condition  -- If provided, if this condition is true, the request will be STALL'd instead
-                                of acknowledged.
-            """
-
-        # Provide an response to the STATUS stage.
-        with m.If(self.interface.status_requested):
-
-            # If our stall condition is met, stall; otherwise, send a ZLP [USB 8.5.3].
-            with m.If(stall_condition):
-                m.d.comb += self.interface.handshakes_out.stall.eq(1)
-            with m.Else():
-                m.d.comb += self.send_zlp()
-
-        # Accept the relevant value after the packet is ACK'd...
-        with m.If(self.interface.handshakes_in.ack):
-            m.d.comb += [
-                write_strobe      .eq(1),
-                new_value_signal  .eq(self.interface.setup.value[0:7])
-            ]
-
-            # ... and then return to idle.
-            m.next = 'IDLE'
-
-
-    def handle_simple_data_request(self, m, transmitter, data, length=1):
-        """ Fills in a given current state with a request that returns a given piece of data.
-
-        For e.g. GET_CONFIGURATION and GET_STATUS requests.
-
-        Parameters:
-            transmitter -- The transmitter module we're working with.
-            data        -- The data to be returned.
-        """
-
-        # Connect our transmitter up to the output stream...
-        m.d.comb += [
-            transmitter.stream          .attach(self.interface.tx),
-            Cat(transmitter.data[0:length]).eq(data),
-            transmitter.max_length      .eq(length)
-        ]
-
-        # ... trigger it to respond when data's requested...
-        with m.If(self.interface.data_requested):
-            m.d.comb += transmitter.start.eq(1)
-
-        # ... and ACK our status stage.
-        with m.If(self.interface.status_requested):
-            m.d.comb += self.interface.handshakes_out.ack.eq(1)
-            m.next = 'IDLE'
-
 
 
     def elaborate(self, platform):

--- a/luna/gateware/usb/usb2/transfer.py
+++ b/luna/gateware/usb/usb2/transfer.py
@@ -215,10 +215,10 @@ class USBInTransferManager(Elaboratable):
                 # If we have valid data that will end our packet, we're no longer waiting for data.
                 # We'll now wait for the host to request data from us.
                 packet_complete = (write_fill_count + 1 == self._max_packet_size)
-                will_end_packet = packet_complete | in_stream.last
+                will_end_packet = in_stream.valid & (packet_complete | in_stream.last)
 
                 # If we've just finished a packet, we now have data we can send!
-                with m.If(in_stream.valid & will_end_packet):
+                with m.If(will_end_packet):
                     m.next = "WAIT_TO_SEND"
                     m.d.usb += [
 

--- a/luna/gateware/usb/usb2/transfer.py
+++ b/luna/gateware/usb/usb2/transfer.py
@@ -42,6 +42,11 @@ class USBInTransferManager(Elaboratable):
     packet_stream: USBInStreamInterface, output stream
         Output stream; broken into packets to be sent.
 
+    flush: Signal(), input
+        If high, data that is currently buffered will be sent out as soon as possible. The module will
+        not wait further for the input stream to end, or to have a max-length packet; it will send a
+        packet as soon as possible.
+
     data_pid: Signal(2), output
         The LSBs of the data PID to be issued with the current packet. Used with :attr:`packet_stream`
         to indicate the PID of the transmitted packet.
@@ -82,6 +87,8 @@ class USBInTransferManager(Elaboratable):
 
         self.transfer_stream  = StreamInterface()
         self.packet_stream    = USBInStreamInterface()
+
+        self.flush            = Signal()
 
         # Note: we'll start with DATA1 in our register; as we'll toggle our data PID
         # before we send.
@@ -203,6 +210,14 @@ class USBInTransferManager(Elaboratable):
         packet_nearly_full = (write_fill_count + 1 == self._max_packet_size)
         packet_completing = in_stream.valid & (in_stream.last | packet_nearly_full)
 
+        # We should also send a packet when both:
+        # - Our flush input is asserted
+        # - We have some data in the buffer to flush.
+        packet_to_flush = self.flush & (write_fill_count != 0)
+
+        # We're ready to send a packet when either of the above conditions is met.
+        packet_ready = packet_completing | packet_to_flush
+
         # Shortcut for when we need to deal with an in token.
         # Pulses high an interpacket delay after receiving an IN token.
         in_token_received = self.active & self.tokenizer.is_in & self.tokenizer.ready_for_response
@@ -218,7 +233,7 @@ class USBInTransferManager(Elaboratable):
                 m.d.comb += self.handshakes_out.nak.eq(in_token_received)
 
                 # If we've just finished a packet, we now have data we can send!
-                with m.If(packet_completing):
+                with m.If(packet_ready):
                     m.next = "WAIT_TO_SEND"
                     m.d.usb += [
 
@@ -314,7 +329,7 @@ class USBInTransferManager(Elaboratable):
                     # for us in our "write buffer", which we've been filling in the background.
                     # If this is the case, we'll flip which buffer we're working with, toggle our data pid,
                     # and then ready ourselves for transmit.
-                    with m.Elif(~in_stream.ready | packet_completing):
+                    with m.Elif(~in_stream.ready | packet_ready):
                         m.next = "WAIT_TO_SEND"
                         m.d.usb += [
                             self.buffer_toggle .eq(~self.buffer_toggle),


### PR DESCRIPTION
This PR adds an initial mechanism for the host to control LUNA's USB analyzer gateware, allowing capture to be started and stopped by software.

This is not intended to reflect any final design for the analyzer's USB control interface. It is just intended to be sufficient to close #149 and start making the analyzer more usable.

The changes are as follows:

1. Take some generic parts of `StandardRequestHandler`, and move them into a new `ControlRequestHandler` base class, which can also be used for vendor & class requests.
2. Add a vendor request handler to `USBAnalyzerApplet`, with requests allowing the host to read and write a register.
3. Add an enable signal to `USBAnalyzer`, and connect it to one bit of the host-controlled register.

These first changes are sufficient for the host to start and stop the capture and prevent overruns. However, in order to flush the remaining data to the host correctly once the capture stops, some further changes are needed as explained [here](https://github.com/greatscottgadgets/luna/issues/121#issuecomment-1080640961). For now, I have gone with the simple solution of adding a `flush` control to `USBInStreamEndpoint`, rather than making broader changes to `StreamInterface` as proposed in #121:

4. Do some cleanup work in `USBInTransferManager`, to centralise the logic for when a packet should be sent.
5. Add a `flush` signal to `USBInStreamEndpoint` and `USBInTransferManager`, which when asserted will cause pending data to be sent out as soon as possible.
6. Connect the `flush` signal in `USBAnalyzerApplet`, so as to flush the endpoint after capture is stopped.

Finally, address an edge case in the analyzer:

7. Make sure that capture cannot start in the middle of a packet, by arming only when capture is enabled and UTMI RX inactive.

A command line capture program that uses this control mechanism is available in [this repository](https://github.com/greatscottgadgets/luna-analyzer-capture). To test it, ensure the Python `luna` module is installed with these changes, and then run from that repository:
```
make
python setup-analyzer.py
./capture > capture.dat
```
The capture data can be converted to pcap format by piping through the `luna2pcap` tool also found in that repository.