### PR TITLE
gateware.applets.analyzer: fix import get_appropriate_platform

### DIFF
--- a/luna/gateware/applets/analyzer.py
+++ b/luna/gateware/applets/analyzer.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from amaranth                         import Signal, Elaboratable, Module
 from usb_protocol.emitters            import DeviceDescriptorCollection
 
-from luna                             import get_appropriate_platform
+from luna.gateware.platform           import get_appropriate_platform
 from luna.usb2                        import USBDevice, USBStreamInEndpoint
 
 from luna.gateware.utils.cdc          import synchronize


### PR DESCRIPTION
f4da0ed caused luna top module not import get_appropriate_platform by default, which broke the analyzer.