### PR TITLE
gateware.request.standard: Correctly handle requests for non-existent descriptors.

### DIFF
--- a/luna/gateware/usb/request/standard.py
+++ b/luna/gateware/usb/request/standard.py
@@ -244,6 +244,10 @@ class StandardRequestHandler(USBRequestHandler):
                         m.d.comb += handshake_generator.ack.eq(1)
                         m.next = 'IDLE'
 
+                    # If the requested descriptor doesn't exist, the request is terminated by STALLing the data stage.
+                    with m.If(get_descriptor_handler.stall):
+                        m.d.usb += expecting_ack.eq(0)
+                        m.next = 'IDLE'
 
                 # GET_CONFIGURATION -- The host is asking for the active configuration number.
                 with m.State('GET_CONFIGURATION'):


### PR DESCRIPTION
## Issue
When a non-existent descriptor is requested, the descriptor handler is correctly STALLing the request, but the standard request handler remains stuck in the `GET_DESCRIPTOR` state, with the `expecting_ack` flag set. If an unrelated ACK then arrives before the next descriptor request, it's causing the descriptor handler to skip ahead into an invalid state, producing similar symptoms to #139.

## Reproducing
Run e.g. `lsusb -v` while there's other IN activity ongoing. `lsusb` will attempt to request a debug descriptor, which will trigger this issue when it doesn't exist.

With an Orbtrace, the issue can be reproduced by starting a trace session with `orbuculum --orbtrace "-T4 -v3"` and then running `lsusb -vd 1209:3443 | grep iInterface` in another shell. Symptoms of this issue then looks like this:
```console
zyp@odyssey:~$ lsusb -vd 1209:3443 | grep iInterface
      iInterface              0 
      iInterface              0 
      iInterface              4 Trace
can't get debug descriptor: Resource temporarily unavailable
cannot read device status, Resource temporarily unavailable (11)
      iInterface              5 Control Proxy
      iInterface              6 CMSIS-DAP v1
      iInterface              7 CMSIS-DAP v2
      iInterface              8 Target power
      iInterface              9 Version: v1.1.0-19-gfe1280a-dirty
zyp@odyssey:~$ lsusb -vd 1209:3443 | grep iInterface
      iInterface              0 
      iInterface              0 
      iInterface              4 (error)
can't get debug descriptor: Resource temporarily unavailable
cannot read device status, Resource temporarily unavailable (11)
      iInterface              5 (error)
      iInterface              6 (error)
      iInterface              7 (error)
      iInterface              8 (error)
      iInterface              9 (error)
```
The debug descriptor is the last descriptor request performed and will trigger the issue at the end of the first `lsusb` call. The erroneous state then causes all following descriptor requests to fail.
## Fix
When a STALL handshake is sent, reset `expecting_ack` and return to `IDLE` state.