### PR TITLE
gateware.usb2: send ZLP when the descriptor length is a multiple of the maximum packet size.

### DIFF
--- a/luna/gateware/usb/usb2/descriptor.py
+++ b/luna/gateware/usb/usb2/descriptor.py
@@ -398,7 +398,10 @@ class GetDescriptorHandlerBlock(Elaboratable):
             m.d.sync += length.eq(self._max_packet_length)
 
         # Register that stores our current position in the stream.
-        position_in_stream = Signal(range(descriptor_max_length))
+        # We still want to be able to store a position beyond bounds (+1),
+        # this is required for descriptors length multiple of the maximum packet size.
+        # Like this we do not overflow our position and are able to send a ZLP on the next request.
+        position_in_stream = Signal(range(descriptor_max_length + 1))
         bytes_sent = Signal.like(length)
 
         # Registers that store descriptor length and data base address.
@@ -488,7 +491,13 @@ class GetDescriptorHandlerBlock(Elaboratable):
                     descriptor_length             .eq(rom_element_count),
                 ]
 
-                m.next = 'SEND_DESCRIPTOR'
+                # Our current position may point out of bounds in case our descriptor length is a multiple
+                # of the maximum packet size. We must send a ZLP now so the host knows the previous
+                # packet was the end of the descriptor.
+                with m.If(position_in_stream >= rom_element_count):
+                    m.next = "SEND_ZLP"
+                with m.Else():
+                    m.next = 'SEND_DESCRIPTOR'
 
 
             # SEND_DESCRIPTOR -- we finally are actively streaming our descriptor; which we'll complete until


### PR DESCRIPTION
## Issue

When the descriptor length is equal to the max packet size (for example 64), and the host requests more (for example on windows the request length is 255 (0xff)), the ZLP is not correctly sent. The first 64 bytes are sent during the first IN request, and the next IN are not answered (no DATA) by the device. This causes the device to become unresponsive. See pic:

![image](https://user-images.githubusercontent.com/1533712/194385959-541c7089-5c7b-40f8-997a-b549e7303cbf.png)

## Fix

Send the ZLP. See pic:

![image](https://user-images.githubusercontent.com/1533712/194387025-353870f9-4f92-4692-bd1f-c87e5decf43b.png)
