### PR TITLE
gateware.soc: bring SimpleSoC up to date with upstream changes to amaranth-soc and lambdasoc

### DIFF
--- a/luna/__init__.py
+++ b/luna/__init__.py
@@ -25,7 +25,7 @@ def configure_default_logging(level=logging.INFO, logger=logging):
     else:
         log_format = LOG_FORMAT_PLAIN
 
-    logger.basicConfig(level=logging.INFO, format=log_format)
+    logger.basicConfig(level=level, format=log_format)
 
 
 def top_level_cli(fragment, *pos_args, cli_soc=None, **kwargs):
@@ -181,5 +181,3 @@ def top_level_cli(fragment, *pos_args, cli_soc=None, **kwargs):
             shutil.rmtree(build_dir)
 
     return None
-
-

--- a/luna/gateware/soc/memory.py
+++ b/luna/gateware/soc/memory.py
@@ -85,9 +85,9 @@ class WishboneRAM(Elaboratable):
         # Note that we provide the -local- address to the Interface object; as it automatically factors
         # in our extra bits as it computes our granularity.
         self.bus = wishbone.Interface(addr_width=self.local_addr_width, data_width=data_width, granularity=granularity)
-        self.bus.memory_map = memory.MemoryMap(addr_width=self.bus_addr_width, data_width=granularity)
-        self.bus.memory_map.add_resource(self, size=2 ** addr_width)
-
+        memory_map = memory.MemoryMap(addr_width=self.bus_addr_width, data_width=granularity, name=self.name)
+        memory_map.add_resource(self, size=2 ** addr_width, name=self.name)
+        self.bus.memory_map = memory_map
 
     def elaborate(self, platform):
         m = Module()


### PR DESCRIPTION
The main upstream changes affecting SimpleSoC were:

1. Assigning a memory map to a bus freezes the memory 
2. The names of several mandatory SoC members have changed: `rom` -> `bootrom`, `ram` -> `scratchpad`
3. The addition of new, mandatory SoC properties: `mainram`, `sram`
4. `AsyncSerialPeripheral` construction has changed.
5. The bus `memory_map.windows()` method now returns an iterator over amaranth_soc.memory.MemoryMap rather than a tuple.
6. The memory map `all_resources()` method now returns an iterator over amaranth_soc.memory.ResourceInfo rather than a tuple.

Closes https://github.com/greatscottgadgets/luna/issues/167
Closes https://github.com/greatscottgadgets/luna/issues/187