### PR TITLE
gateware.usb.usb2.USBPacketID: fix .byte() type

### DIFF
--- a/luna/gateware/test/usb2.py
+++ b/luna/gateware/test/usb2.py
@@ -6,7 +6,8 @@
 
 """ Full-device test harnesses for USB2. """
 
-from usb_protocol.types import USBStandardRequests, USBPacketID
+from usb_protocol.types import USBStandardRequests
+from ..usb.usb2         import USBPacketID
 
 from .                  import LunaGatewareTestCase
 

--- a/luna/gateware/usb/usb2/__init__.py
+++ b/luna/gateware/usb/usb2/__init__.py
@@ -159,7 +159,7 @@ class USBPacketID(IntFlag):
     def byte(self):
         """ Return the value with its upper nibble. """
 
-        inverted_pid = self ^ 0b1111
-        full_pid     = (inverted_pid << 4) | self
+        inverted_pid = int(self) ^ 0b1111
+        full_pid     = (inverted_pid << 4) | int(self)
 
         return full_pid


### PR DESCRIPTION
This fixes a bug that was revealed recently due to Amaranth HDL changing how enumerations are converted to a `Value`, as their shape is now defined by the maximum value.
In particular, the `USBPacketID.byte()` method was returning a mangled `USBPacketID` instead of an `int`, and when assigned to an Amaranth HDL `Value` the upper bits were lost.

Fixes #198