### PR TITLE
applets: add a bi-directional bulk_speed_test applet

### DIFF
--- a/luna/gateware/applets/speed_test.py
+++ b/luna/gateware/applets/speed_test.py
@@ -1,8 +1,10 @@
 from amaranth                import *
 from usb_protocol.emitters   import DeviceDescriptorCollection, SuperSpeedDeviceDescriptorCollection
 
-from luna.usb2               import USBDevice, USBStreamInEndpoint
+from luna.usb2               import USBDevice, USBStreamInEndpoint, USBStreamOutEndpoint
 from luna.usb3               import USBSuperSpeedDevice, SuperSpeedStreamInEndpoint
+
+from luna.gateware.platform  import NullPin
 
 VENDOR_ID  = 0x16d0
 PRODUCT_ID = 0x0f3b
@@ -10,8 +12,8 @@ PRODUCT_ID = 0x0f3b
 BULK_ENDPOINT_NUMBER = 1
 
 
-class USBInSpeedTestDevice(Elaboratable):
-    """ Simple device that sends data to the host as fast as hardware can. """
+class USBSpeedTestDevice(Elaboratable):
+    """ Simple device that exchanges data with the host as fast as the hardware can. """
 
     def __init__(self, fs_only=False, phy=None):
         self.fs_only = fs_only
@@ -34,7 +36,7 @@ class USBInSpeedTestDevice(Elaboratable):
             d.idProduct          = PRODUCT_ID
 
             d.iManufacturer      = "LUNA"
-            d.iProduct           = "IN speed test"
+            d.iProduct           = "speed test"
             d.iSerialNumber      = "no serial"
 
             d.bNumConfigurations = 1
@@ -46,8 +48,14 @@ class USBInSpeedTestDevice(Elaboratable):
             with c.InterfaceDescriptor() as i:
                 i.bInterfaceNumber = 0
 
+                # Bulk IN to host (tx, from our side)
                 with i.EndpointDescriptor() as e:
                     e.bEndpointAddress = 0x80 | BULK_ENDPOINT_NUMBER
+                    e.wMaxPacketSize   = self.max_bulk_packet_size
+
+                # Bulk OUT to host (rx, from our side)
+                with i.EndpointDescriptor() as e:
+                    e.bEndpointAddress = BULK_ENDPOINT_NUMBER
                     e.wMaxPacketSize   = self.max_bulk_packet_size
 
 
@@ -76,18 +84,48 @@ class USBInSpeedTestDevice(Elaboratable):
         descriptors = self.create_descriptors()
         usb.add_standard_control_endpoint(descriptors)
 
-        # Add a stream endpoint to our device.
-        stream_ep = USBStreamInEndpoint(
+
+        # Add a stream endpoint to our device for Bulk IN transfers.
+        stream_in_ep = USBStreamInEndpoint(
             endpoint_number=BULK_ENDPOINT_NUMBER,
             max_packet_size=self.max_bulk_packet_size
         )
-        usb.add_endpoint(stream_ep)
+        usb.add_endpoint(stream_in_ep)
 
-        # Send entirely zeroes, as fast as we can.
+        # Create a simple data source that increments whenever the
+        # endpoint is accepting data.
+        counter = Signal(8)
+        with m.If(stream_in_ep.stream.ready):
+            m.d.sync += counter.eq(counter + 1)
+
+        # Send our IN data stream, as fast as we can.
         m.d.comb += [
-            stream_ep.stream.valid    .eq(1),
-            stream_ep.stream.payload  .eq(0)
+            stream_in_ep.stream.valid    .eq(1),
+            stream_in_ep.stream.payload  .eq(counter)
         ]
+
+
+        # Add a stream endpoint to our device for Bulk OUT transfers.
+        stream_out_ep = USBStreamOutEndpoint(
+            endpoint_number=BULK_ENDPOINT_NUMBER,
+            max_packet_size=self.max_bulk_packet_size
+        )
+        usb.add_endpoint(stream_out_ep)
+
+        # Always accept data as it comes in.
+        m.d.comb += stream_out_ep.stream.ready.eq(1)
+
+        # Receive our OUT data stream, as fast as we can and output
+        # the received data to our User I/O and LEDS
+        leds   = Cat(platform.request_optional("led", i, default=NullPin()) for i in range(6))
+        pmod_a = platform.request_optional("user_pmod", 0, default=NullPin(8))
+        with m.If(stream_out_ep.stream.valid):
+            m.d.comb += [
+                leds.eq(stream_out_ep.stream.payload[2:8]),
+                pmod_a.o.eq(stream_out_ep.stream.payload),
+                pmod_a.oe.eq(1),
+            ]
+
 
         # Connect our device as a high speed device by default.
         m.d.comb += [

--- a/luna/gateware/applets/speed_test.py
+++ b/luna/gateware/applets/speed_test.py
@@ -117,7 +117,7 @@ class USBSpeedTestDevice(Elaboratable):
 
         # Receive our OUT data stream, as fast as we can and output
         # the received data to our User I/O and LEDS
-        leds   = Cat(platform.request_optional("led", i, default=NullPin()) for i in range(6))
+        leds   = Cat(platform.request_optional("led", i, default=NullPin()).o for i in range(6))
         pmod_a = platform.request_optional("user_pmod", 0, default=NullPin(8))
         with m.If(stream_out_ep.stream.valid):
             m.d.comb += [


### PR DESCRIPTION
This PR adds a new applet that is able to form a bi-directional bulk speed test.

I don't have access to SuperSpeed hardware so I thought it best to implement this separately to the `bulk_in_speed_test.py` applet for now.

New features added:

* Addition of a new OUT endpoint. (Added bonus: the speed test device will now enumerate under macOS)
* Vendor request handler to manage the switch between IN/OUT test.
* Data sent by the IN test is now an 8-bit counter rather than zeros.
* OUT test mirrors received data on device LED's and PMOD A.

There is one area where I am not 100% sure I'm doing the right thing in the gateware implementation and that is the logic for when a given IN or OUT test is inactive:

**IN test:**

https://github.com/antoinevg/luna/blob/791498f1eabb3632453770a5a3c5f7d3876e3c2a/applets/bulk_speed_test.py#L229-L236


**OUT test:**

https://github.com/antoinevg/luna/blob/791498f1eabb3632453770a5a3c5f7d3876e3c2a/applets/bulk_speed_test.py#L266-L270
