### PR TITLE
Discard data in FIFO and endpoint buffer when restarting analyzer

### DIFF
--- a/luna/gateware/applets/analyzer.py
+++ b/luna/gateware/applets/analyzer.py
@@ -249,6 +249,9 @@ class USBAnalyzerApplet(Elaboratable):
             # Flush endpoint when analyzer is idle with capture disabled.
             stream_ep.flush             .eq(analyzer.idle & ~analyzer.capture_enable),
 
+            # Discard data buffered by endpoint when the analyzer discards its data.
+            stream_ep.discard           .eq(analyzer.discarding),
+
             # USB stream uplink.
             stream_ep.stream            .stream_eq(analyzer.stream),
 

--- a/luna/gateware/usb/analyzer.py
+++ b/luna/gateware/usb/analyzer.py
@@ -211,7 +211,7 @@ class USBAnalyzer(Elaboratable):
                     # Optimization: if we didn't receive any data, there's no need
                     # to create a packet. Clear our header from the FIFO and disarm.
                     with m.If(packet_size == 0):
-                        m.next = "START"
+                        m.next = "IDLE"
                         m.d.usb += [
                             write_location.eq(header_location)
                         ]
@@ -244,7 +244,7 @@ class USBAnalyzer(Elaboratable):
                     mem_write_port.en    .eq(1),
                     fifo_new_data        .eq(1)
                 ]
-                m.next = "START"
+                m.next = "IDLE"
 
 
             # BABBLE -- handles the case in which we've received a packet beyond

--- a/luna/gateware/usb/usb2/endpoints/stream.py
+++ b/luna/gateware/usb/usb2/endpoints/stream.py
@@ -43,6 +43,9 @@ class USBStreamInEndpoint(Elaboratable):
     flush: Signal(), input
         Assert to cause all pending data to be transmitted as soon as possible.
 
+    discard: Signal(), input
+        Assert to cause all pending data to be discarded.
+
     interface: EndpointInterface
         Communications link to our USB device.
 
@@ -68,6 +71,7 @@ class USBStreamInEndpoint(Elaboratable):
         self.stream    = StreamInterface()
         self.interface = EndpointInterface()
         self.flush     = Signal()
+        self.discard   = Signal()
 
 
     def elaborate(self, platform):
@@ -85,9 +89,10 @@ class USBStreamInEndpoint(Elaboratable):
             # We want to handle packets only that target our endpoint number.
             tx_manager.active           .eq(interface.tokenizer.endpoint == self._endpoint_number),
 
-            # Connect up our transfer manager to our input stream and flush control...
+            # Connect up our transfer manager to our input stream, flush and discard control...
             tx_manager.transfer_stream  .stream_eq(self.stream),
             tx_manager.flush            .eq(self.flush),
+            tx_manager.discard          .eq(self.discard),
 
             # ... and our output stream...
             interface.tx                .stream_eq(tx_manager.packet_stream),


### PR DESCRIPTION
This PR fixes problems with stale data being read from the analyzer after capture is stopped and restarted.

Thanks to @miek for fixes!