### PR TITLE
gateware.usb2: add disconnect signal to USBResetSequencer

### DIFF
--- a/luna/gateware/usb/usb2/device.py
+++ b/luna/gateware/usb/usb2/device.py
@@ -243,6 +243,8 @@ class USBDevice(Elaboratable):
 
             reset_sequencer.vbus_connected  .eq(~self.utmi.session_end),
             reset_sequencer.line_state      .eq(self.utmi.line_state),
+
+            reset_sequencer.disconnect      .eq(~self.connect),
         ]
 
 

--- a/luna/gateware/usb/usb2/reset.py
+++ b/luna/gateware/usb/usb2/reset.py
@@ -532,8 +532,12 @@ class USBResetSequencer(Elaboratable):
 
                 # Exit DISCONNECT once the Tddis timer has expired and self.disconnect is low.
                 with m.If((~self.disconnect) & tddis):
-                    m.d.usb += tddis.eq(0)
-                    m.d.usb += timer.eq(0)
-                    m.next = 'START_HS_DETECTION'
+                    m.d.usb += [
+                        tddis.eq(0),
+                        self.current_speed.eq(USBSpeed.FULL),
+                        self.operating_mode.eq(UTMIOperatingMode.NORMAL),
+                        self.termination_select.eq(1),
+                    ]
+                    m.next = 'INITIALIZE'
 
         return m

--- a/luna/gateware/usb/usb2/reset.py
+++ b/luna/gateware/usb/usb2/reset.py
@@ -170,20 +170,13 @@ class USBResetSequencer(Elaboratable):
         with m.If(self.current_speed == USBSpeed.HIGH):
             m.d.comb += bus_idle.eq(self.line_state == self._LINE_STATE_SQUELCH)
 
-        # Full and low-speed busses see a 'J' state when idle, due to the device pull-up restistors.
+        # Full and low-speed busses see a 'J' state when idle, due to the device pull-up resistors.
         # (The line_state values for these are flipped between speeds.) [USB2.0: 7.1.7.4.1; USB2.0: Table 7-2].
         with m.Elif(self.current_speed == USBSpeed.FULL):
             m.d.comb += bus_idle.eq(self.line_state == self._LINE_STATE_FS_HS_J)
         with m.Else():
             m.d.comb += bus_idle.eq(self.line_state == self._LINE_STATE_LS_J)
 
-        # Switch to non-driving operating mode when we're not
-        # connected and we're not seeing an SE0.
-        with m.If(self.disconnect & (self.line_state != self._LINE_STATE_SE0)):
-            m.d.usb += [
-                self.operating_mode.eq(UTMIOperatingMode.NON_DRIVING),
-                timer.eq(0),
-            ]
 
         #
         # Core reset sequences.
@@ -211,7 +204,9 @@ class USBResetSequencer(Elaboratable):
                 # potential reset. Keep our timer at zero.
                 with m.If(self.line_state != self._LINE_STATE_SE0):
                     m.d.usb += timer.eq(0)
-
+                    # Enter forced disconnect when self.disconnect is high.
+                    with m.If(self.disconnect):
+                        m.next = "DISCONNECT"
 
                 # If VBUS isn't connected, don't go through the whole reset process;
                 # but also consider ourselves permanently in reset. This ensures we
@@ -253,6 +248,9 @@ class USBResetSequencer(Elaboratable):
                 # potential reset. Keep our timer at zero.
                 with m.If(self.line_state != self._LINE_STATE_SE0):
                     m.d.usb += timer.eq(0)
+                    # Enter forced disconnect when self.disconnect is high.
+                    with m.If(self.disconnect):
+                        m.next = "DISCONNECT"
 
                 # If VBUS isn't connected, our device/host relationship is effectively
                 # a blank state. We'll want to present our detection pull-up to the host,
@@ -518,5 +516,24 @@ class USBResetSequencer(Elaboratable):
                     # Otherwise, this could be a high-speed device; enter its reset.
                     with m.Else():
                         m.next = 'START_HS_DETECTION'
+
+
+            # DISCONNECT -- our device has entered a forced USB disconnect; hold the device in
+            # NON_DRIVING operating mode for Tddis=0.25us and wait for self.disconnect to go low.
+            with m.State('DISCONNECT'):
+                m.d.usb += self.operating_mode.eq(UTMIOperatingMode.NON_DRIVING)
+
+                # A disconnect condition is indicated if the host or hub is not driving the data lines and an
+                # SE0 persists on a downstream facing port for more than Tddis.
+                # [USB2.0: 7.1.7.3].
+                tddis = Signal()
+                with m.If(timer == self._CYCLES_2P5_MICROSECONDS):
+                    m.d.usb += tddis.eq(1)
+
+                # Exit DISCONNECT once the Tddis timer has expired and self.disconnect is low.
+                with m.If((~self.disconnect) & tddis):
+                    m.d.usb += tddis.eq(0)
+                    m.d.usb += timer.eq(0)
+                    m.next = 'START_HS_DETECTION'
 
         return m


### PR DESCRIPTION
This draft PR adds a `disconnect` signal that, when pulled high by `USBDevice`, causes the UTMI interface's operating mode to be set to `NON_DRIVING` in order to trigger a host disconnect.

Open questions:

* Is this the best place to put the logic? e.g. Would it be better to tie it to the `USBResetSequencer` state machine and only operate if we're in state `LS_FS_NON_RESET` or `HS_NON_RESET`?
* ~~I've run into some weirdness where, after data has been transferred on any of the non control endpoints, I can no longer enumerate the device after disconnect/connect. This may however be due to a bug in my code. Currently investigating.~~  It was indeed a software bug.