### PR TITLE
gateware: update for amaranth rfc-22 compatibility

### DIFF
--- a/luna/gateware/interface/jtag.py
+++ b/luna/gateware/interface/jtag.py
@@ -127,6 +127,8 @@ class ECP5DebugSPIBridge(Elaboratable, ValueCastable):
             'cs':  self.cs
         }[key]
 
+    def shape(self):
+        return self.as_value().shape()
 
     def _synchronize_(self, m, output, o_domain="sync", stages=2):
         """ Creates a synchronized copy of this interface's I/O. """


### PR DESCRIPTION
Amaranth [RFC-22: Define ValueCastable.shape()](https://amaranth-lang.org/rfcs/0022-valuecastable-shape.html#define-valuecastableshape) causes a compilation error with the message:

```
TypeError: Class `ECP5DebugSPIBridge' deriving from `ValueCastable` must override the `shape` method
```

This PR provides an implementation of the `shape()` method for `ECP5DebugSPIBridge` to resolve the issue.

Other potential resolutions discussed include:

* Drop derivation of `ECP5DebugSPIBridge` from `ValueCastable`.
* Drop `ECP5DebugSPIBridge` from the repository as it is not actually in use by the library.