### PR TITLE
gateware.usb.usb2.descriptor: provide unsigned offset to .word_select()

### DIFF
--- a/luna/gateware/usb/usb2/descriptor.py
+++ b/luna/gateware/usb/usb2/descriptor.py
@@ -511,7 +511,7 @@ class GetDescriptorHandlerBlock(Elaboratable):
 
                     # Always drive the stream from our current memory output...
                     rom_read_port.addr  .eq(descriptor_data_base_address + word_in_stream),
-                    self.tx.payload     .eq(rom_read_port.data.word_select(3 - byte_in_stream, 8)),
+                    self.tx.payload     .eq(rom_read_port.data.word_select(~byte_in_stream, 8)),
 
                     # ... and base First and Last based on our current position in the stream.
                     self.tx.first       .eq(on_first_packet),


### PR DESCRIPTION
This PR fixes #217 by making sure an unsigned offset is passed to the `.word_select()` method.

Recent Amaranth HDL versions cast the subtraction to a `signed(3)` value, which is later rejected by `word_select()`. The `.as_unsigned()` method could also be used as a fix here, but inverting the value of `byte_in_stream` results in the same operation without a width extension.