### PR TITLE
gateware: do not use Pin as a value

### DIFF
--- a/applets/interactive-test.py
+++ b/applets/interactive-test.py
@@ -91,7 +91,7 @@ class InteractiveSelftest(Elaboratable, ApolloSelfTestCase):
 
         # LED test register.
         led_reg = registers.add_register(REGISTER_LEDS, size=6, name="leds", reset=0b111111)
-        led_out   = Cat([platform.request("led", i, dir="o") for i in range(0, 6)])
+        led_out   = Cat([platform.request("led", i, dir="o").o for i in range(0, 6)])
         m.d.comb += led_out.eq(led_reg)
 
         #
@@ -125,7 +125,7 @@ class InteractiveSelftest(Elaboratable, ApolloSelfTestCase):
 
         # Hook up our PSRAM.
         m.d.comb += [
-            ram_bus.reset          .eq(0),
+            ram_bus.reset.o        .eq(0),
             psram.single_page      .eq(0),
             psram.perform_write    .eq(0),
             psram.register_space   .eq(1),
@@ -150,9 +150,9 @@ class InteractiveSelftest(Elaboratable, ApolloSelfTestCase):
             ulpi_reg_window.ulpi_dir      .eq(target_ulpi.dir.i),
             ulpi_reg_window.ulpi_next     .eq(target_ulpi.nxt.i),
 
-            target_ulpi.clk      .eq(ClockSignal("usb")),
-            target_ulpi.rst      .eq(ResetSignal("usb")),
-            target_ulpi.stp      .eq(ulpi_reg_window.ulpi_stop),
+            target_ulpi.clk.o    .eq(ClockSignal("usb")),
+            target_ulpi.rst.o    .eq(ResetSignal("usb")),
+            target_ulpi.stp.o    .eq(ulpi_reg_window.ulpi_stop),
             target_ulpi.data.o   .eq(ulpi_reg_window.ulpi_data_out),
             target_ulpi.data.oe  .eq(~target_ulpi.dir.i)
         ]

--- a/applets/ulpi-test.py
+++ b/applets/ulpi-test.py
@@ -103,10 +103,10 @@ class ULPIDiagnostic(Elaboratable):
 
         # Debug output.
         m.d.comb += [
-            platform.request("user_io", 0, dir="o") .eq(ClockSignal("usb")),
-            platform.request("user_io", 1, dir="o") .eq(ulpi.dir),
-            platform.request("user_io", 2, dir="o") .eq(ulpi.nxt),
-            platform.request("user_io", 3, dir="o") .eq(analyzer.sampling),
+            platform.request("user_io", 0, dir="o").o .eq(ClockSignal("usb")),
+            platform.request("user_io", 1, dir="o").o .eq(ulpi.dir),
+            platform.request("user_io", 2, dir="o").o .eq(ulpi.nxt),
+            platform.request("user_io", 3, dir="o").o .eq(analyzer.sampling),
         ]
 
 

--- a/examples/debugging/basic_ila.py
+++ b/examples/debugging/basic_ila.py
@@ -40,7 +40,7 @@ class ILAExample(Elaboratable):
         m.d.comb += self.ila.trigger.eq(self.counter == 7)
 
         # Grab our I/O connectors.
-        leds    = [platform.request_optional("led", i, default=NullPin(), dir="o") for i in range(0, 6)]
+        leds    = [platform.request_optional("led", i, default=NullPin(), dir="o").o for i in range(0, 6)]
         spi_bus = synchronize(m, platform.request('debug_spi'))
 
         # Attach the LEDs and User I/O to the MSBs of our counter.

--- a/examples/debugging/basic_ila_fast_domain.py
+++ b/examples/debugging/basic_ila_fast_domain.py
@@ -54,7 +54,7 @@ class ILAExample(Elaboratable):
         m.d.comb += self.ila.trigger.eq(self.counter == 7)
 
         # Grab our I/O connectors.
-        leds    = [platform.request("led", i, dir="o") for i in range(0, 6)]
+        leds    = [platform.request("led", i, dir="o").o for i in range(0, 6)]
         spi_bus = synchronize(m, platform.request('debug_spi'), o_domain='fast')
 
         # Attach the LEDs and User I/O to the MSBs of our counter.

--- a/examples/debugging/ila_shared_bus.py
+++ b/examples/debugging/ila_shared_bus.py
@@ -57,7 +57,7 @@ class ILASharedBusExample(Elaboratable):
             # chip select to our ILA bus. This will allow us to send
             # ILA data when CS is un-asserted, and register data when
             # CS is asserted.
-            ila_spi.cs  .eq(~board_spi.cs)
+            ila_spi.cs  .eq(~board_spi.cs.i)
         ]
 
         # Create a set of registers...
@@ -68,7 +68,7 @@ class ILASharedBusExample(Elaboratable):
         reg_spi = SPIBus()
         m.d.comb += [
             spi_registers.spi .connect(reg_spi),
-            reg_spi.cs        .eq(board_spi.cs)
+            reg_spi.cs        .eq(board_spi.cs.i)
         ]
 
         # Multiplex our ILA and register SPI busses.
@@ -86,7 +86,7 @@ class ILASharedBusExample(Elaboratable):
         )
 
         # Attach the LEDs and User I/O to the MSBs of our counter.
-        leds    = [platform.request("led", i, dir="o") for i in range(0, 6)]
+        leds    = [platform.request("led", i, dir="o").o for i in range(0, 6)]
         m.d.comb += Cat(leds).eq(self.counter[-7:-1])
 
         # Return our elaborated module.

--- a/examples/hw_features/debug_spi.py
+++ b/examples/hw_features/debug_spi.py
@@ -37,7 +37,7 @@ class DebugSPIExample(Elaboratable):
         m.d.comb  += self.interface.spi.connect(spi)
 
         # Turn on a single LED, just to show something's running.
-        led = platform.request('led', 0)
+        led = platform.request('led', 0).o
         m.d.comb += led.eq(1)
 
         # Echo back the last received data.

--- a/examples/hw_features/uart_bridge.py
+++ b/examples/hw_features/uart_bridge.py
@@ -61,7 +61,7 @@ class UARTBridgeExample(Elaboratable):
 
 
         # Turn on a single LED, just to show something's running.
-        led = Cat(platform.request('led', i) for i in range(6))
+        led = Cat(platform.request('led', i).o for i in range(6))
         m.d.comb += led.eq(~transmitter.tx)
 
         return m

--- a/examples/usb/stream_out_device.py
+++ b/examples/usb/stream_out_device.py
@@ -81,8 +81,8 @@ class USBStreamOutDeviceExample(Elaboratable):
         )
         usb.add_endpoint(stream_ep)
 
-        leds    = Cat(platform.request_optional("led", i, default=NullPin()) for i in range(6))
-        user_io = Cat(platform.request_optional("user_io", i, default=NullPin()) for i in range(4))
+        leds    = Cat(platform.request_optional("led", i, default=NullPin()).o for i in range(6))
+        user_io = Cat(platform.request_optional("user_io", i, default=NullPin()).o for i in range(4))
 
         # Always stream our USB data directly onto our User I/O and LEDS.
         with m.If(stream_ep.stream.valid):

--- a/luna/gateware/applets/dc_flash.py
+++ b/luna/gateware/applets/dc_flash.py
@@ -41,8 +41,8 @@ class DebugControllerFlashBridge(Elaboratable):
 
         m.submodules += spi_flash_passthrough
         m.d.comb += [
-            spi_flash_passthrough.sck   .eq(board_spi.sck),
-            spi_flash_passthrough.sdi   .eq(board_spi.sdi),
+            spi_flash_passthrough.sck   .eq(board_spi.sck.i),
+            spi_flash_passthrough.sdi   .eq(board_spi.sdi.i),
             flash_sdo                   .eq(spi_flash_passthrough.sdo),
         ]
 
@@ -53,17 +53,17 @@ class DebugControllerFlashBridge(Elaboratable):
 
         # Select the passthrough or gateware SPI based on our chip-select values.
         gateware_sdo = Signal()
-        with m.If(board_spi.cs):
-            m.d.comb += board_spi.sdo.eq(gateware_sdo)
+        with m.If(board_spi.cs.i):
+            m.d.comb += board_spi.sdo.o.eq(gateware_sdo)
         with m.Else():
-            m.d.comb += board_spi.sdo.eq(flash_sdo)
+            m.d.comb += board_spi.sdo.o.eq(flash_sdo)
 
         # Connect our register interface to our board SPI.
         m.d.comb += [
-            spi_registers.spi.sck .eq(spi.sck),
-            spi_registers.spi.sdi .eq(spi.sdi),
+            spi_registers.spi.sck .eq(spi.sck.i),
+            spi_registers.spi.sdi .eq(spi.sdi.i),
             gateware_sdo          .eq(spi_registers.spi.sdo),
-            spi_registers.spi.cs  .eq(spi.cs)
+            spi_registers.spi.cs  .eq(spi.cs.i)
         ]
 
         return m

--- a/luna/gateware/architecture/car.py
+++ b/luna/gateware/architecture/car.py
@@ -295,7 +295,7 @@ class LunaECP5DomainGenerator(LunaDomainGenerator):
             m.submodules += Instance("OSCG", p_DIV=self.OSCG_DIV, o_OSC=input_clock)
             pll_params["CLKFB_DIV"] = 4
         else:
-            input_clock = platform.request(clock_name)
+            input_clock = platform.request(clock_name).i
 
             divisor = 240e6 / clock_frequency
             if not divisor.is_integer():


### PR DESCRIPTION
The recent implementation of RFC-2 in Amaranth HDL caused some problems within LUNA: the code contains many instances of `Pin` used as a value.

This PR tries to fix all of them by referencing the internal signals instead (`.o`, `.i`, etc.).