### PR TITLE
gateware.usb.usb2.request: `USBRequestHandler` defines managed requests

### DIFF
--- a/examples/usb/vendor_request.py
+++ b/examples/usb/vendor_request.py
@@ -20,6 +20,9 @@ class LEDRequestHandler(USBRequestHandler):
 
     REQUEST_SET_LEDS = 0
 
+    def handled(self, setup):
+        return (setup.type == USBRequestType.VENDOR) & (setup.request == self.REQUEST_SET_LEDS)
+
     def elaborate(self, platform):
         m = Module()
 
@@ -56,16 +59,7 @@ class LEDRequestHandler(USBRequestHandler):
                     with m.If(interface.status_requested):
                         m.d.comb += self.send_zlp()
 
-
-                with m.Case():
-
-                    #
-                    # Stall unhandled requests.
-                    #
-                    with m.If(interface.status_requested | interface.data_requested):
-                        m.d.comb += interface.handshakes_out.stall.eq(1)
-
-                return m
+        return m
 
 
 

--- a/luna/gateware/usb/request/standard.py
+++ b/luna/gateware/usb/request/standard.py
@@ -55,6 +55,8 @@ class StandardRequestHandler(ControlRequestHandler):
 
         super().__init__()
 
+    def handled(self, setup):
+        return setup.type == USBRequestType.STANDARD
 
     def elaborate(self, platform):
         m = Module()

--- a/luna/gateware/usb/usb2/request.py
+++ b/luna/gateware/usb/usb2/request.py
@@ -101,6 +101,8 @@ class USBRequestHandler(Elaboratable):
         #
         self.interface = RequestHandlerInterface()
 
+    def handled(self, setup):
+        raise NotImplementedError("Please define `handled` for all registered request handlers.")
 
     def send_zlp(self):
         """ Returns the statements necessary to send a zero-length packet."""


### PR DESCRIPTION
This commit adds a `handled()` method to `USBRequestHandler`. This method takes a `SetupPacket` as an argument and returns an Amaranth boolean indicating whether a request has been taken care of.

These signals from the various request handlers are subsequently combined to trigger a stall for unhandled cases.