### PR TITLE
Pin Amaranth version 0.4 & clean-up dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ authors = [
 ]
 description = "Amaranth HDL framework for FPGA-based USB solutions"
 readme = "README.md"
-requires-python = ">=3.8,<4.0"
+requires-python = "~=3.8"
 dependencies = [
     "apollo-fpga>=0.0.5",
     "libusb1>1.9.2",
     "pyserial>=3.5",
     "pyusb>1.1.1",
     "pyvcd>=0.2.4",
-    "amaranth @ git+https://github.com/amaranth-lang/amaranth",
+    "amaranth~=0.4.0",
     "amaranth-boards @ git+https://github.com/amaranth-lang/amaranth-boards.git@main",
     "usb-protocol @ git+https://github.com/usb-tools/python-usb-protocol",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "pyvcd>=0.2.4",
     "ziglang>0.8.0",
     "amaranth @ git+https://github.com/amaranth-lang/amaranth",
-    "amaranth-soc @ git+https://github.com/amaranth-lang/amaranth-soc.git@main",
     "amaranth-boards @ git+https://github.com/amaranth-lang/amaranth-boards.git@main",
     "usb-protocol @ git+https://github.com/usb-tools/python-usb-protocol",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "pyserial>=3.5",
     "pyusb>1.1.1",
     "pyvcd>=0.2.4",
-    "ziglang>0.8.0",
     "amaranth @ git+https://github.com/amaranth-lang/amaranth",
     "amaranth-boards @ git+https://github.com/amaranth-lang/amaranth-boards.git@main",
     "usb-protocol @ git+https://github.com/usb-tools/python-usb-protocol",
@@ -27,8 +26,6 @@ dependencies = [
 dev = [
     "prompt-toolkit>3.0.16",
     "tox>3.22.0",
-    "minerva @ git+https://github.com/lambdaconcept/minerva.git",
-    "amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio.git@main",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 tox
 pyusb
-git+https://github.com/amaranth-lang/amaranth
+amaranth~=0.4.0
 -e git+https://github.com/amaranth-lang/amaranth-boards.git#egg=amaranth_boards
 -e git+https://github.com/usb-tools/python-usb-protocol.git#egg=usb_protocol
 pyvcd

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,6 @@
 tox
 pyusb
 git+https://github.com/amaranth-lang/amaranth
--e git+https://github.com/amaranth-lang/amaranth-soc.git#egg=amaranth-soc
 -e git+https://github.com/amaranth-lang/amaranth-boards.git#egg=amaranth_boards
 -e git+https://github.com/usb-tools/python-usb-protocol.git#egg=usb_protocol
 pyvcd


### PR DESCRIPTION
This updates the dependency on Amaranth to pin the newly-released version 0.4 instead of depending on the git version (which is currently broken as we rely on some components that have been removed).

I also removed the `amaranth-soc` dependency as that conflicts with the `amaranth` dependency. We could wait for them to update, but I don't think the dependency makes sense now that all the soc components have moved to [luna-soc](https://github.com/greatscottgadgets/luna-soc). The dependency was only kept at that time because the (unused) `UARTTransmitterPeripheral` class depends on it.

I also removed a few dependencies that were just completely unused, including `amaranth-stdio` that also conflicted.