### PR TITLE
gateware.interface.psram: update HyperRAM interface

### DIFF
--- a/applets/hyperram_diagnostic.py
+++ b/applets/hyperram_diagnostic.py
@@ -18,7 +18,7 @@ from luna                             import top_level_cli
 from apollo_fpga                      import ApolloDebugger
 from luna.gateware.interface.jtag     import JTAGRegisterInterface
 from luna.gateware.architecture.car   import LunaECP5DomainGenerator
-from luna.gateware.interface.psram    import HyperRAMInterface
+from luna.gateware.interface.psram    import HyperRAMPHY, HyperRAMInterface
 
 REGISTER_RAM_ADDR           = 2
 REGISTER_RAM_FIFO           = 3
@@ -47,14 +47,14 @@ class HyperRAMDiagnostic(Elaboratable):
         # HyperRAM test connections.
         #
         ram_bus = platform.request('ram')
-        psram = HyperRAMInterface(bus=ram_bus, **platform.ram_timings)
-        m.submodules += psram
+        psram_phy = HyperRAMPHY(bus=ram_bus)
+        psram = HyperRAMInterface(phy=psram_phy.phy)
+        m.submodules += [psram_phy, psram]
 
         psram_address = registers.add_register(REGISTER_RAM_ADDR)
 
         m.submodules.read_fifo  = read_fifo  = SyncFIFO(width=16, depth=32)
         m.submodules.write_fifo = write_fifo = SyncFIFO(width=16, depth=32)
-
         registers.add_sfr(REGISTER_RAM_FIFO,
             read=read_fifo.r_data,
             read_strobe=read_fifo.r_en,

--- a/applets/hyperram_diagnostic.py
+++ b/applets/hyperram_diagnostic.py
@@ -81,6 +81,7 @@ class HyperRAMDiagnostic(Elaboratable):
             psram.write_data       .eq(write_fifo.r_data),
             read_fifo.w_data       .eq(psram.read_data),
             read_fifo.w_en         .eq(psram.new_data_ready),
+            write_fifo.r_en        .eq(psram.write_ready),
         ]
 
         # Return our elaborated module.

--- a/applets/hyperram_diagnostic.py
+++ b/applets/hyperram_diagnostic.py
@@ -101,7 +101,7 @@ class HyperRAMDiagnostic(Elaboratable):
             psram.address          .eq(psram_address),
             psram.write_data       .eq(write_fifo.r_data),
             read_fifo.w_data       .eq(psram.read_data),
-            read_fifo.w_en         .eq(psram.new_data_ready),
+            read_fifo.w_en         .eq(psram.read_ready),
             write_fifo.r_en        .eq(psram.write_ready),
         ]
 

--- a/applets/hyperram_diagnostic.py
+++ b/applets/hyperram_diagnostic.py
@@ -99,7 +99,7 @@ class HyperRAMDiagnostic(Elaboratable):
 
         # Hook up our PSRAM.
         m.d.comb += [
-            ram_bus.reset          .eq(0),
+            ram_bus.reset.o        .eq(0),
             psram.single_page      .eq(0),
             psram.register_space   .eq(register_space),
             psram.final_word       .eq(final_word),

--- a/applets/hyperram_diagnostic.py
+++ b/applets/hyperram_diagnostic.py
@@ -161,10 +161,12 @@ if __name__ == "__main__":
         dut.registers.register_write(REGISTER_RAM_READ_LENGTH, 10)
         dut.registers.register_read(REGISTER_RAM_START)
 
+        # Verify data.
         for addr in range(len(data)):
             result = dut.registers.register_read(REGISTER_RAM_FIFO)
-            print(f"{result=:x} {data[addr]=:x} {addr=}")
-
+            if result != data[addr]:
+                print(f"{result=:x} {data[addr]=:x} {addr=}")
+                return False
 
         return True
 
@@ -173,10 +175,10 @@ if __name__ == "__main__":
         for i in range(iterations):
 
             if test():
-                pprint(f".", end="")
+                pprint(".", end="")
                 passes += 1
             else:
-                pprint(f"✗", end="")
+                pprint("✗", end="")
 
                 failures += 1
                 failed_tests.add(test)
@@ -185,8 +187,9 @@ if __name__ == "__main__":
     pass_text = "<green>✓ PASSED</green>"
     pprint(HTML("\n\n<b><u>Results:</u></b>"))
 
-    pprint(HTML(f"    ID READ:     {fail_text if test_id_read in failed_tests else pass_text}"))
-    pprint(HTML(f"    CONFIG READ: {fail_text if test_config_read in failed_tests else pass_text}"))
+    pprint(HTML(f"    ID READ:      {fail_text if test_id_read in failed_tests else pass_text}"))
+    pprint(HTML(f"    CONFIG READ:  {fail_text if test_config_read in failed_tests else pass_text}"))
+    pprint(HTML(f"    MEM READBACK: {fail_text if test_mem_readback in failed_tests else pass_text}"))
 
 
     print(f"\nDiagnostics completed with {passes} passes and {failures} failures.\n")

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -78,6 +78,7 @@ class HyperRAMInterface(Elaboratable):
 
         O: idle             -- High whenever the transmitter is idle (and thus we can start a new piece of data.)
         O: new_data_ready   -- Strobe that indicates when new data is ready for reading
+        O: write_ready      -- Strobe that indicates `write_data` has been latched and is ready for new data
     """
 
     LOW_LATENCY_CLOCKS  = 7
@@ -106,6 +107,7 @@ class HyperRAMInterface(Elaboratable):
         # Status signals.
         self.idle             = Signal()
         self.new_data_ready   = Signal()
+        self.write_ready      = Signal()
 
         # Data signals.
         self.read_data        = Signal(16)
@@ -152,10 +154,12 @@ class HyperRAMInterface(Elaboratable):
             self.phy.clk_en     .eq(1),
             self.new_data_ready .eq(0),
 
+
             self.phy.cs         .eq(1),
             self.phy.rwds.e     .eq(0),
             self.phy.dq.e       .eq(0),
         ]
+        m.d.comb += self.write_ready.eq(0),
 
         # Commands, in order of bytes sent:
         #   - WRBAAAAA
@@ -289,6 +293,7 @@ class HyperRAMInterface(Elaboratable):
                     self.phy.rwds.e  .eq(~is_register),
                     self.phy.rwds.o  .eq(0),
                 ]
+                m.d.comb += self.write_ready.eq(1),
 
                 # If we just finished a register write, we're done -- there's no need for recovery.
                 with m.If(is_register):

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -280,10 +280,6 @@ class HyperRAMInterface(Elaboratable):
                     with m.If(self.final_word):
                         m.next = 'RECOVERY'
 
-                    with m.Else():
-                        #m.next = 'READ_DATA_MSB'
-                        m.next = 'RECOVERY'
-
 
             # WRITE_DATA_LSB -- write the first of our two bytes of data to the to the PSRAM
             with m.State("WRITE_DATA"):

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -77,7 +77,7 @@ class HyperRAMInterface(Elaboratable):
         I: write_data[16]   -- word that accepts the data to output during this transaction
 
         O: idle             -- High whenever the transmitter is idle (and thus we can start a new piece of data.)
-        O: new_data_ready   -- Strobe that indicates when new data is ready for reading
+        O: read_ready       -- Strobe that indicates when new data is ready for reading
         O: write_ready      -- Strobe that indicates `write_data` has been latched and is ready for new data
     """
 
@@ -106,7 +106,7 @@ class HyperRAMInterface(Elaboratable):
 
         # Status signals.
         self.idle             = Signal()
-        self.new_data_ready   = Signal()
+        self.read_ready       = Signal()
         self.write_ready      = Signal()
 
         # Data signals.
@@ -152,7 +152,7 @@ class HyperRAMInterface(Elaboratable):
         # Provide defaults for our control/status signals.
         m.d.sync += [
             self.phy.clk_en     .eq(1),
-            self.new_data_ready .eq(0),
+            self.read_ready     .eq(0),
 
 
             self.phy.cs         .eq(1),
@@ -273,7 +273,7 @@ class HyperRAMInterface(Elaboratable):
                 with m.If(self.phy.rwds.i == 0b10):
                     m.d.sync += [
                         self.read_data.eq(self.phy.dq.i),
-                        self.new_data_ready.eq(1)
+                        self.read_ready    .eq(1)
                     ]
 
                     # If our controller is done with the transcation, end it.
@@ -476,7 +476,7 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
 
         # Once this finished, we should have a result on our data out.
         self.assertEqual((yield self.dut.read_data),      0xCAFE)
-        self.assertEqual((yield self.dut.new_data_ready), 1)
+        self.assertEqual((yield self.dut.read_ready    ), 1)
 
         yield
         self.assertEqual((yield self.ram_signals.cs),     0)

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -302,10 +302,6 @@ class HyperRAMInterface(Elaboratable):
                 with m.Elif(self.final_word):
                     m.next = 'RECOVERY'
 
-                with m.Else():
-                    #m.next = 'READ_DATA_MSB'
-                    m.next = 'RECOVERY'
-
 
             # RECOVERY state: wait for the required period of time before a new transaction
             with m.State('RECOVERY'):

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -12,33 +12,11 @@ from amaranth import Const, Signal, Module, Cat, Elaboratable, Record, ClockSign
 from amaranth.hdl.rec import DIR_FANIN, DIR_FANOUT
 from amaranth.lib.cdc import FFSynchronizer
 
-from ..utils.io   import delay
 from ..test.utils import LunaGatewareTestCase, sync_test_case
 
 
-class HyperBus(Record):
-    """ Record representing an HyperBus (DDR-ish connection for HyperRAM). """
-
-    def __init__(self):
-        super().__init__([
-            ('clk', 1, DIR_FANOUT),
-            ('dq',
-                ('i', 8, DIR_FANIN),
-                ('o', 8, DIR_FANOUT),
-                ('e', 1, DIR_FANOUT),
-            ),
-            ('rwds',
-                ('i', 1, DIR_FANIN),
-                ('o', 1, DIR_FANOUT),
-                ('e', 1, DIR_FANOUT),
-            ),
-            ('cs',     1, DIR_FANOUT),
-            ('reset',  1, DIR_FANOUT)
-        ])
-
-
 class HyperBusPHY(Record):
-    """ Record representing an 16-bit HyperBus interface for use with a 2:1 PHY module. """
+    """ Record representing a 16-bit HyperBus interface for use with a 2:1 PHY module. """
 
     def __init__(self):
         super().__init__([

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -271,9 +271,9 @@ class HyperRAMInterface(Elaboratable):
                 # If RWDS has changed, the host has just sent us new data.
                 # Sample it, and indicate that we now have a valid piece of new data.
                 with m.If(self.phy.rwds.i == 0b10):
-                    m.d.sync += [
-                        self.read_data.eq(self.phy.dq.i),
-                        self.read_ready    .eq(1)
+                    m.d.comb += [
+                        self.read_data     .eq(self.phy.dq.i),
+                        self.read_ready    .eq(1),
                     ]
 
                     # If our controller is done with the transcation, end it.

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -464,12 +464,12 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
         yield self.ram_signals.dq.i.eq(0xCAFE)
         yield self.ram_signals.rwds.i.eq(0b10)
         yield
-        yield
 
         # Once this finished, we should have a result on our data out.
         self.assertEqual((yield self.dut.read_data),      0xCAFE)
         self.assertEqual((yield self.dut.read_ready    ), 1)
 
+        yield
         yield
         self.assertEqual((yield self.ram_signals.cs),     0)
         self.assertEqual((yield self.ram_signals.dq.e),   0)
@@ -492,7 +492,6 @@ class HyperRAMPHY(Elaboratable):
     def __init__(self, *, bus, in_skew=None, out_skew=None, clock_skew=None):
         self.bus = bus
         self.phy = HyperBusPHY()
-        self.rwds_in = Signal()
 
     def elaborate(self, platform):
         m = Module()

--- a/luna/gateware/interface/psram.py
+++ b/luna/gateware/interface/psram.py
@@ -8,8 +8,9 @@
 
 import unittest
 
-from amaranth import Const, Signal, Module, Cat, Elaboratable, Record
+from amaranth import Const, Signal, Module, Cat, Elaboratable, Record, ClockSignal, ResetSignal, Instance
 from amaranth.hdl.rec import DIR_FANIN, DIR_FANOUT
+from amaranth.lib.cdc import FFSynchronizer
 
 from ..utils.io   import delay
 from ..test.utils import LunaGatewareTestCase, sync_test_case
@@ -36,12 +37,32 @@ class HyperBus(Record):
         ])
 
 
+class HyperBusPHY(Record):
+    """ Record representing an 16-bit HyperBus interface for use with a 2:1 PHY module. """
+
+    def __init__(self):
+        super().__init__([
+            ('clk_en', 1, DIR_FANOUT),
+            ('dq', [
+                ('i', 16, DIR_FANIN),
+                ('o', 16, DIR_FANOUT),
+                ('e', 1,  DIR_FANOUT),
+            ]),
+            ('rwds', [
+                ('i', 2,  DIR_FANIN),
+                ('o', 2,  DIR_FANOUT),
+                ('e', 1,  DIR_FANOUT),
+            ]),
+            ('cs',     1, DIR_FANOUT),
+            ('reset',  1, DIR_FANOUT)
+        ])
+
 
 class HyperRAMInterface(Elaboratable):
     """ Gateware interface to HyperRAM series self-refreshing DRAM chips.
 
     I/O port:
-        B: bus              -- The primary physical connection to the DRAM chip.
+        B: phy              -- The primary physical connection to the DRAM chip.
         I: reset            -- An active-high signal used to provide a prolonged reset upon configuration.
 
         I: address[32]      -- The address to be targeted by the given operation.
@@ -59,26 +80,19 @@ class HyperRAMInterface(Elaboratable):
         O: new_data_ready   -- Strobe that indicates when new data is ready for reading
     """
 
-    LOW_LATENCY_EDGES  = 12
-    HIGH_LATENCY_EDGES = 26
+    LOW_LATENCY_CLOCKS  = 7
+    HIGH_LATENCY_CLOCKS = 14
 
-    def __init__(self, *, bus, in_skew=None, out_skew=None, clock_skew=None):
+    def __init__(self, *, phy):
         """
         Parmeters:
-            bus           -- The RAM record that should be connected to this RAM chip.
-            data_skews    -- If provided, adds an input delay to each line of the data input.
-                             Can be provided as a single delay number, or an interable of eight
-                             delays to separately delay each of the input lines.
+            phy           -- The RAM record that should be connected to this RAM chip.
         """
-
-        self.in_skew    = in_skew
-        self.out_skew   = out_skew
-        self.clock_skew = clock_skew
 
         #
         # I/O port.
         #
-        self.bus              = bus
+        self.phy              = phy
         self.reset            = Signal()
 
         # Control signals.
@@ -104,41 +118,6 @@ class HyperRAMInterface(Elaboratable):
         m = Module()
 
         #
-        # Delayed input and output.
-        #
-
-        if self.in_skew is not None:
-            data_in = delay(m, self.bus.dq.i, self.in_skew)
-        else:
-            data_in = self.bus.dq.i
-
-        data_oe = self.bus.dq.oe
-        if self.out_skew is not None:
-            data_out = Signal.like(self.bus.dq.o)
-            delay(m, data_out, self.out_skew, out=self.bus.dq.o)
-        else:
-            data_out = self.bus.dq.o
-
-
-        #
-        # Transaction clock generator.
-        #
-        advance_clock  = Signal()
-        reset_clock    = Signal()
-
-        if self.clock_skew is not None:
-            out_clock = Signal()
-            delay(m, out_clock, self.clock_skew, out=self.bus.clk)
-        else:
-            out_clock = self.bus.clk
-
-        with m.If(reset_clock):
-            m.d.sync += out_clock.eq(0)
-        with m.Elif(advance_clock):
-            m.d.sync += out_clock.eq(~out_clock)
-        m.d.comb += self.clk.eq(out_clock)
-
-        #
         # Latched control/addressing signals.
         #
         is_read         = Signal()
@@ -156,16 +135,13 @@ class HyperRAMInterface(Elaboratable):
 
         # Tracks how many cycles of latency we have remaining between a command
         # and the relevant data stages.
-        latency_edges_remaining  = Signal(range(0, self.HIGH_LATENCY_EDGES + 1))
+        latency_clocks_remaining  = Signal(range(0, self.HIGH_LATENCY_CLOCKS + 1))
 
         # One cycle delayed version of RWDS.
         # This is used to detect edges in RWDS during reads, which semantically mean
         # we should accept new data.
-        last_rwds = Signal.like(self.bus.rwds.i)
-        m.d.sync += last_rwds.eq(self.bus.rwds.i)
-
-        # Create a sync-domain version of our 'new data ready' signal.
-        new_data_ready = self.new_data_ready
+        last_rwds = Signal.like(self.phy.rwds.i)
+        m.d.sync += last_rwds.eq(self.phy.rwds.i)
 
         #
         # Core operation FSM.
@@ -173,13 +149,12 @@ class HyperRAMInterface(Elaboratable):
 
         # Provide defaults for our control/status signals.
         m.d.sync += [
-            advance_clock       .eq(1),
-            reset_clock         .eq(0),
-            new_data_ready      .eq(0),
+            self.phy.clk_en     .eq(1),
+            self.new_data_ready .eq(0),
 
-            self.bus.cs         .eq(1),
-            self.bus.rwds.oe    .eq(0),
-            self.bus.dq.oe      .eq(0),
+            self.phy.cs         .eq(1),
+            self.phy.rwds.e     .eq(0),
+            self.phy.dq.e       .eq(0),
         ]
 
         # Commands, in order of bytes sent:
@@ -208,8 +183,8 @@ class HyperRAMInterface(Elaboratable):
 
             # IDLE state: waits for a transaction request
             with m.State('IDLE'):
-                m.d.sync += reset_clock      .eq(1)
                 m.d.comb += self.idle        .eq(1)
+                m.d.sync += self.phy.clk_en  .eq(0)
 
                 # Once we have a transaction request, latch in our control
                 # signals, and assert our chip-select.
@@ -221,73 +196,47 @@ class HyperRAMInterface(Elaboratable):
                         is_register         .eq(self.register_space),
                         is_multipage        .eq(~self.single_page),
                         current_address     .eq(self.address),
+                        self.phy.dq.o       .eq(0),
                     ]
 
                 with m.Else():
-                    m.d.sync += self.bus.cs.eq(0)
+                    m.d.sync += self.phy.cs.eq(0)
 
 
-            # LATCH_RWDS -- latch in the value of the RWDS signal, which determines
-            # our read/write latency. Note that we advance the clock in this state,
-            # as our out-of-phase clock signal will output the relevant data before
-            # the next edge can occur.
+            # LATCH_RWDS -- latch in the value of the RWDS signal,
+            # which determines our read/write latency.
             with m.State("LATCH_RWDS"):
-                m.d.sync += extra_latency.eq(self.bus.rwds.i),
+                m.d.sync += extra_latency.eq(self.phy.rwds.i),
+                m.d.sync += self.phy.clk_en.eq(0)
                 m.next="SHIFT_COMMAND0"
 
 
-            # SHIFT_COMMANDx -- shift each of our command bytes out
+            # SHIFT_COMMANDx -- shift each of our command words out
             with m.State('SHIFT_COMMAND0'):
                 # Output our first byte of our command.
                 m.d.sync += [
-                    data_out  .eq(ca[40:48]),
-                    data_oe   .eq(1)
+                    self.phy.dq.o.eq(ca[32:48]),
+                    self.phy.dq.e.eq(1)
                 ]
                 m.next = 'SHIFT_COMMAND1'
 
-            # Note: it's felt that this is more readable with each of these
-            # states defined explicitly. If you strongly disagree, feel free
-            # to PR a for-loop, here.~
-
-
             with m.State('SHIFT_COMMAND1'):
                 m.d.sync += [
-                    data_out  .eq(ca[32:40]),
-                    data_oe   .eq(1)
+                    self.phy.dq.o.eq(ca[16:32]),
+                    self.phy.dq.e.eq(1)
                 ]
                 m.next = 'SHIFT_COMMAND2'
 
             with m.State('SHIFT_COMMAND2'):
                 m.d.sync += [
-                    data_out  .eq(ca[24:32]),
-                    data_oe   .eq(1)
-                ]
-                m.next = 'SHIFT_COMMAND3'
-
-            with m.State('SHIFT_COMMAND3'):
-                m.d.sync += [
-                    data_out  .eq(ca[16:24]),
-                    data_oe   .eq(1)
-                ]
-                m.next = 'SHIFT_COMMAND4'
-
-            with m.State('SHIFT_COMMAND4'):
-                m.d.sync += [
-                    data_out  .eq(ca[8:16]),
-                    data_oe   .eq(1)
-                ]
-                m.next = 'SHIFT_COMMAND5'
-
-            with m.State('SHIFT_COMMAND5'):
-                m.d.sync += [
-                    data_out  .eq(ca[0:8]),
-                    data_oe   .eq(1)
+                    self.phy.dq.o.eq(ca[0:16]),
+                    self.phy.dq.e.eq(1)
                 ]
 
                 # If we have a register write, we don't need to handle
                 # any latency. Move directly to our SHIFT_DATA state.
                 with m.If(is_register & ~is_read):
-                    m.next = 'WRITE_DATA_MSB'
+                    m.next = 'WRITE_DATA'
 
                 # Otherwise, react with either a short period of latency
                 # or a longer one, depending on what the RAM requested via
@@ -295,82 +244,58 @@ class HyperRAMInterface(Elaboratable):
                 with m.Else():
                     m.next = "HANDLE_LATENCY"
 
-                    with m.If(extra_latency):
-                        m.d.sync += latency_edges_remaining.eq(self.HIGH_LATENCY_EDGES-1)
+                    with m.If(extra_latency | 1):
+                        m.d.sync += latency_clocks_remaining.eq(self.HIGH_LATENCY_CLOCKS-2)
                     with m.Else():
-                        m.d.sync += latency_edges_remaining.eq(self.LOW_LATENCY_EDGES-1)
+                        m.d.sync += latency_clocks_remaining.eq(self.LOW_LATENCY_CLOCKS-2)
 
 
             # HANDLE_LATENCY -- applies clock edges until our latency period is over.
             with m.State('HANDLE_LATENCY'):
-                m.d.sync += latency_edges_remaining.eq(latency_edges_remaining - 1)
+                m.d.sync += latency_clocks_remaining.eq(latency_clocks_remaining - 1)
 
-                with m.If(latency_edges_remaining == 0):
+                with m.If(latency_clocks_remaining == 0):
                     with m.If(is_read):
-                        m.next = 'READ_DATA_MSB'
+                        m.next = 'READ_DATA'
                     with m.Else():
-                        m.next = 'WRITE_DATA_MSB'
-
-
-            # STREAM_DATA_MSB -- scans in or out the first byte of data
-            with m.State('READ_DATA_MSB'):
-
-                # If RWDS has changed, the host has just sent us new data.
-                with m.If(self.bus.rwds.i != last_rwds):
-                    m.d.sync += self.read_data[8:16].eq(data_in)
-                    m.next = 'READ_DATA_LSB'
+                        m.next = 'WRITE_DATA'
 
 
             # STREAM_DATA_LSB -- scans in or out the second byte of data
-            with m.State('READ_DATA_LSB'):
+            with m.State('READ_DATA'):
 
                 # If RWDS has changed, the host has just sent us new data.
                 # Sample it, and indicate that we now have a valid piece of new data.
-                with m.If(self.bus.rwds.i != last_rwds):
+                with m.If(self.phy.rwds.i == 0b10):
                     m.d.sync += [
-                        self.read_data[0:8]  .eq(data_in),
-                        new_data_ready       .eq(1)
+                        self.read_data.eq(self.phy.dq.i),
+                        self.new_data_ready.eq(1)
                     ]
 
                     # If our controller is done with the transcation, end it.
                     with m.If(self.final_word):
                         m.next = 'RECOVERY'
-                        m.d.sync += advance_clock.eq(0)
 
                     with m.Else():
                         #m.next = 'READ_DATA_MSB'
                         m.next = 'RECOVERY'
 
 
-            # WRITE_DATA_MSB -- write the first of our two bytes of data to the to the PSRAM
-            with m.State("WRITE_DATA_MSB"):
-                m.d.sync += [
-                    data_out         .eq(self.write_data[8:16]),
-                    data_oe          .eq(1),
-                    self.bus.rwds.oe .eq(~is_register),
-                    self.bus.rwds.o  .eq(0),
-                ]
-                m.next = "WRITE_DATA_LSB"
-
-
             # WRITE_DATA_LSB -- write the first of our two bytes of data to the to the PSRAM
-            with m.State("WRITE_DATA_LSB"):
+            with m.State("WRITE_DATA"):
                 m.d.sync += [
-                    data_out         .eq(self.write_data[0:8]),
-                    data_oe          .eq(1),
-                    self.bus.rwds.oe .eq(~is_register),
-                    self.bus.rwds.o  .eq(0),
+                    self.phy.dq.o    .eq(self.write_data),
+                    self.phy.dq.e    .eq(1),
+                    self.phy.rwds.e  .eq(~is_register),
+                    self.phy.rwds.o  .eq(0),
                 ]
-                m.next = "WRITE_DATA_LSB"
 
                 # If we just finished a register write, we're done -- there's no need for recovery.
                 with m.If(is_register):
                     m.next = 'IDLE'
-                    m.d.sync += advance_clock.eq(0)
 
                 with m.Elif(self.final_word):
                     m.next = 'RECOVERY'
-                    m.d.sync += advance_clock.eq(0)
 
                 with m.Else():
                     #m.next = 'READ_DATA_MSB'
@@ -380,8 +305,8 @@ class HyperRAMInterface(Elaboratable):
             # RECOVERY state: wait for the required period of time before a new transaction
             with m.State('RECOVERY'):
                 m.d.sync += [
-                    self.bus.cs   .eq(0),
-                    advance_clock .eq(0)
+                    self.phy.cs     .eq(0),
+                    self.phy.clk_en .eq(0)
                 ]
 
                 # TODO: implement recovery
@@ -396,17 +321,10 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
 
     def instantiate_dut(self):
         # Create a record that recreates the layout of our RAM signals.
-        self.ram_signals = Record([
-            ("clk",   1),
-            ("clkN",  1),
-            ("dq",   [("i",  8), ("o",  8), ("oe", 1)]),
-            ("rwds", [("i",  1), ("o",  1), ("oe", 1)]),
-            ("cs",    1),
-            ("reset", 1)
-        ])
+        self.ram_signals = HyperBusPHY()
 
         # Create our HyperRAM interface...
-        return HyperRAMInterface(bus=self.ram_signals)
+        return HyperRAMInterface(phy=self.ram_signals)
 
 
     def assert_clock_pulses(self, times=1):
@@ -414,9 +332,7 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
 
         for _ in range(times):
             yield
-            self.assertEqual((yield self.ram_signals.clk), 1)
-            yield
-            self.assertEqual((yield self.ram_signals.clk), 0)
+            self.assertEqual((yield self.ram_signals.clk_en), 1)
 
 
     @sync_test_case
@@ -425,8 +341,8 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
         # Before we transact, CS should be de-asserted, and RWDS and DQ should be undriven.
         yield
         self.assertEqual((yield self.ram_signals.cs),      0)
-        self.assertEqual((yield self.ram_signals.dq.oe),   0)
-        self.assertEqual((yield self.ram_signals.rwds.oe), 0)
+        self.assertEqual((yield self.ram_signals.dq.e),    0)
+        self.assertEqual((yield self.ram_signals.rwds.e),  0)
 
         yield from self.advance_cycles(10)
         self.assertEqual((yield self.ram_signals.cs),      0)
@@ -445,8 +361,8 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
 
         # Ensure that upon requesting, CS goes high, and our clock starts low.
         yield
-        self.assertEqual((yield self.ram_signals.cs),  1)
-        self.assertEqual((yield self.ram_signals.clk), 0)
+        self.assertEqual((yield self.ram_signals.cs),     1)
+        self.assertEqual((yield self.ram_signals.clk_en), 0)
 
         # Drop our "start request" line somewhere during the transaction;
         # so we don't immediately go into the next transfer.
@@ -457,45 +373,27 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
         yield
         yield
         self.assertEqual((yield self.ram_signals.cs),       1)
-        self.assertEqual((yield self.ram_signals.clk),      1)
-        self.assertEqual((yield self.ram_signals.dq.oe),    1)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x60)
-
-        # Next, on the falling edge of our clock, the next byte should be presented.
-        yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x17)
+        self.assertEqual((yield self.ram_signals.clk_en),   1)
+        self.assertEqual((yield self.ram_signals.dq.e),     1)
+        self.assertEqual((yield self.ram_signals.dq.o),  0x6017)
 
         # This should continue until we've shifted out a full command.
         yield
-        self.assertEqual((yield self.ram_signals.clk),      1)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x79)
+        self.assertEqual((yield self.ram_signals.dq.o),  0x799B)
         yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x9B)
-        yield
-        self.assertEqual((yield self.ram_signals.clk),      1)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x00)
-        yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x05)
+        self.assertEqual((yield self.ram_signals.dq.o),  0x0005)
 
         # Check that we've been driving our output this whole time,
         # and haven't been driving RWDS.
-        self.assertEqual((yield self.ram_signals.dq.oe),    1)
-        self.assertEqual((yield self.ram_signals.rwds.oe),  0)
+        self.assertEqual((yield self.ram_signals.dq.e),    1)
+        self.assertEqual((yield self.ram_signals.rwds.e),  0)
         yield
 
         # For a _register_ write, there shouldn't be latency period.
         # This means we should continue driving DQ...
-        self.assertEqual((yield self.ram_signals.dq.oe),    1)
-        self.assertEqual((yield self.ram_signals.rwds.oe),  0)
-
-        self.assertEqual((yield self.ram_signals.clk),      1)
-        self.assertEqual((yield self.ram_signals.dq.o),  0xBE)
-        yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
-        self.assertEqual((yield self.ram_signals.dq.o),  0xEF)
+        self.assertEqual((yield self.ram_signals.dq.e),    1)
+        self.assertEqual((yield self.ram_signals.rwds.e),  0)
+        self.assertEqual((yield self.ram_signals.dq.o),  0xBEEF)
 
 
 
@@ -505,8 +403,8 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
         # Before we transact, CS should be de-asserted, and RWDS and DQ should be undriven.
         yield
         self.assertEqual((yield self.ram_signals.cs),      0)
-        self.assertEqual((yield self.ram_signals.dq.oe),   0)
-        self.assertEqual((yield self.ram_signals.rwds.oe), 0)
+        self.assertEqual((yield self.ram_signals.dq.e),   0)
+        self.assertEqual((yield self.ram_signals.rwds.e), 0)
 
         yield from self.advance_cycles(10)
         self.assertEqual((yield self.ram_signals.cs),      0)
@@ -524,8 +422,8 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
 
         # Ensure that upon requesting, CS goes high, and our clock starts low.
         yield
-        self.assertEqual((yield self.ram_signals.cs),  1)
-        self.assertEqual((yield self.ram_signals.clk), 0)
+        self.assertEqual((yield self.ram_signals.cs),     1)
+        self.assertEqual((yield self.ram_signals.clk_en), 0)
 
         # Drop our "start request" line somewhere during the transaction;
         # so we don't immediately go into the next transfer.
@@ -535,59 +433,43 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
         # which means we're driving DQ with the first word of our command.
         yield
         yield
-        self.assertEqual((yield self.ram_signals.cs),       1)
-        self.assertEqual((yield self.ram_signals.clk),      1)
-        self.assertEqual((yield self.ram_signals.dq.oe),    1)
-        self.assertEqual((yield self.ram_signals.dq.o),  0xe0)
-
-        # Next, on the falling edge of our clock, the next byte should be presented.
-        yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x17)
+        self.assertEqual((yield self.ram_signals.cs),         1)
+        self.assertEqual((yield self.ram_signals.clk_en),     1)
+        self.assertEqual((yield self.ram_signals.dq.e),       1)
+        self.assertEqual((yield self.ram_signals.dq.o),  0xe017)
 
         # This should continue until we've shifted out a full command.
         yield
-        self.assertEqual((yield self.ram_signals.clk),      1)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x79)
+        self.assertEqual((yield self.ram_signals.dq.o),  0x799B)
         yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x9B)
-        yield
-        self.assertEqual((yield self.ram_signals.clk),      1)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x00)
-        yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
-        self.assertEqual((yield self.ram_signals.dq.o),  0x05)
+        self.assertEqual((yield self.ram_signals.dq.o),  0x0005)
 
         # Check that we've been driving our output this whole time,
         # and haven't been driving RWDS.
-        self.assertEqual((yield self.ram_signals.dq.oe),    1)
-        self.assertEqual((yield self.ram_signals.rwds.oe),  0)
+        self.assertEqual((yield self.ram_signals.dq.e),    1)
+        self.assertEqual((yield self.ram_signals.rwds.e),  0)
 
         # Once we finish scanning out the word, we should stop driving
         # the data lines, and should finish two latency periods before
         # sending any more data.
         yield
-        self.assertEqual((yield self.ram_signals.dq.oe),    0)
-        self.assertEqual((yield self.ram_signals.rwds.oe),  0)
-        self.assertEqual((yield self.ram_signals.clk),      1)
+        self.assertEqual((yield self.ram_signals.dq.e),    0)
+        self.assertEqual((yield self.ram_signals.rwds.e),  0)
+        self.assertEqual((yield self.ram_signals.clk_en),  1)
 
         # By this point, the RAM will drive RWDS low.
         yield self.ram_signals.rwds.i.eq(0)
 
         # Ensure the clock still ticking...
         yield
-        self.assertEqual((yield self.ram_signals.clk),      0)
+        self.assertEqual((yield self.ram_signals.clk_en),    1)
 
         # ... and remains so for the remainder of the latency period.
-        yield from self.assert_clock_pulses(6)
+        yield from self.assert_clock_pulses(14)
 
         # Now, shift in a pair of data words.
-        yield self.ram_signals.dq.i.eq(0xCA)
-        yield self.ram_signals.rwds.i.eq(1)
-        yield
-        yield self.ram_signals.dq.i.eq(0xFE)
-        yield self.ram_signals.rwds.i.eq(0)
+        yield self.ram_signals.dq.i.eq(0xCAFE)
+        yield self.ram_signals.rwds.i.eq(0b10)
         yield
         yield
 
@@ -596,15 +478,117 @@ class TestHyperRAMInterface(LunaGatewareTestCase):
         self.assertEqual((yield self.dut.new_data_ready), 1)
 
         yield
-        self.assertEqual((yield self.ram_signals.cs),      0)
-        self.assertEqual((yield self.ram_signals.dq.oe),   0)
-        self.assertEqual((yield self.ram_signals.rwds.oe), 0)
+        self.assertEqual((yield self.ram_signals.cs),     0)
+        self.assertEqual((yield self.ram_signals.dq.e),   0)
+        self.assertEqual((yield self.ram_signals.rwds.e), 0)
 
         # Ensure that our clock drops back to '0' during idle cycles.
         yield from self.advance_cycles(2)
-        self.assertEqual((yield self.ram_signals.clk),     0)
+        self.assertEqual((yield self.ram_signals.clk_en),  0)
 
         # TODO: test recovery time
+
+
+class HyperRAMPHY(Elaboratable):
+    """ Gateware interface to HyperRAM series self-refreshing DRAM chips.
+
+    I/O port:
+        B: bus              -- The primary physical connection to the DRAM chip.
+    """
+
+    def __init__(self, *, bus, in_skew=None, out_skew=None, clock_skew=None):
+        self.bus = bus
+        self.phy = HyperBusPHY()
+        self.rwds_in = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules += [
+            FFSynchronizer(self.phy.cs,     self.bus.cs,      stages=3),
+            FFSynchronizer(self.phy.rwds.e, self.bus.rwds.oe, stages=3),
+            FFSynchronizer(self.phy.dq.e,   self.bus.dq.oe,   stages=3),
+        ]
+
+        # Clock
+        clk_out = Signal()
+        m.submodules += [
+            Instance("ODDRX1F",
+                i_D0=self.phy.clk_en,
+                i_D1=0,
+                i_SCLK=ClockSignal(),
+                i_RST=ResetSignal(),
+                o_Q=clk_out,
+            ),
+            Instance("DELAYF",
+                i_A=clk_out,
+                o_Z=self.bus.clk,
+                # TODO: connect up move/load/dir
+                p_DEL_VALUE=int(2e-9 / 25e-12),
+            ),
+        ]
+
+        # RWDS out
+        m.submodules += [
+            Instance("ODDRX1F",
+                i_D0=self.phy.rwds.o[1],
+                i_D1=self.phy.rwds.o[0],
+                i_SCLK=ClockSignal(),
+                i_RST=ResetSignal(),
+                o_Q=self.bus.rwds.o,
+            ),
+        ]
+
+        # RWDS in
+        rwds_in = Signal()
+        m.submodules += [
+            Instance("DELAYF",
+                i_A=self.bus.rwds.i,
+                o_Z=rwds_in,
+                # TODO: connect up move/load/dir
+                p_DEL_VALUE=int(0e-9 / 25e-12),
+            ),
+            Instance("IDDRX1F",
+                i_D=rwds_in,
+                i_SCLK=ClockSignal(),
+                i_RST=ResetSignal(),
+                o_Q0=self.phy.rwds.i[1],
+                o_Q1=self.phy.rwds.i[0],
+            ),
+        ]
+
+        # DQ
+        for i in range(8):
+            # Out
+            m.submodules += [
+                Instance("ODDRX1F",
+                    i_D0=self.phy.dq.o[i+8],
+                    i_D1=self.phy.dq.o[i],
+                    i_SCLK=ClockSignal(),
+                    i_RST=ResetSignal(),
+                    o_Q=self.bus.dq.o[i],
+                ),
+            ]
+
+            # In
+            dq_in = Signal(name=f"dq_in{i}")
+            m.submodules += [
+                Instance("DELAYF",
+                    i_A=self.bus.dq.i[i],
+                    o_Z=dq_in,
+                    # TODO: connect up move/load/dir
+                    p_DEL_VALUE=int(0e-9 / 25e-12),
+                ),
+                Instance("IDDRX1F",
+                    i_D=dq_in,
+                    i_SCLK=ClockSignal(),
+                    i_RST=ResetSignal(),
+                    o_Q0=self.phy.dq.i[i+8],
+                    o_Q1=self.phy.dq.i[i],
+                ),
+            ]
+
+        return m
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The new interface uses ECP5 DDR primitives instead of relying on a logic-generated clock signal.

Updates `interactive_test` and `hyperram_diagnostic` applets as well.
