### PR TITLE
Additional constructor arguments for `USBSpeedTestDevice`

### DIFF
--- a/luna/gateware/applets/speed_test.py
+++ b/luna/gateware/applets/speed_test.py
@@ -15,10 +15,11 @@ BULK_ENDPOINT_NUMBER = 1
 class USBSpeedTestDevice(Elaboratable):
     """ Simple device that exchanges data with the host as fast as the hardware can. """
 
-    def __init__(self, generate_clocks=True, fs_only=False, phy=None):
+    def __init__(self, generate_clocks=True, fs_only=False, phy=None, pid=PRODUCT_ID):
         self.generate_clocks = generate_clocks
         self.fs_only = fs_only
         self.phy = phy
+        self.pid = pid
         self.max_bulk_packet_size = 64 if fs_only else 512
 
     def create_descriptors(self):
@@ -34,7 +35,7 @@ class USBSpeedTestDevice(Elaboratable):
         # We'll need a device descriptor...
         with descriptors.DeviceDescriptor() as d:
             d.idVendor           = VENDOR_ID
-            d.idProduct          = PRODUCT_ID
+            d.idProduct          = self.pid
 
             d.iManufacturer      = "LUNA"
             d.iProduct           = "speed test"

--- a/luna/gateware/applets/speed_test.py
+++ b/luna/gateware/applets/speed_test.py
@@ -15,7 +15,8 @@ BULK_ENDPOINT_NUMBER = 1
 class USBSpeedTestDevice(Elaboratable):
     """ Simple device that exchanges data with the host as fast as the hardware can. """
 
-    def __init__(self, fs_only=False, phy=None):
+    def __init__(self, generate_clocks=True, fs_only=False, phy=None):
+        self.generate_clocks = generate_clocks
         self.fs_only = fs_only
         self.phy = phy
         self.max_bulk_packet_size = 64 if fs_only else 512
@@ -66,7 +67,8 @@ class USBSpeedTestDevice(Elaboratable):
         m = Module()
 
         # Generate our domain clocks/resets.
-        m.submodules.car = platform.clock_domain_generator()
+        if self.generate_clocks:
+            m.submodules.clocks = platform.clock_domain_generator()
 
         # Request default PHY unless another was specified.
         if self.phy is None:
@@ -141,6 +143,9 @@ class USBInSuperSpeedTestDevice(Elaboratable):
 
     MAX_BULK_PACKET_SIZE = 1024
 
+    def __init__(self, generate_clocks=True):
+        self.generate_clocks = generate_clocks
+
     def create_descriptors(self):
         """ Create the descriptors we want to use for our device. """
 
@@ -186,8 +191,9 @@ class USBInSuperSpeedTestDevice(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        # Generate our domain clocks/resets.
-        m.submodules.car = platform.clock_domain_generator()
+        # Generate our clock domains, if needed.
+        if self.generate_clocks:
+            m.submodules.clocks = platform.clock_domain_generator()
 
         # Create our core PIPE PHY. Since PHY configuration is per-board, we'll just ask
         # our platform for a pre-configured USB3 PHY.

--- a/luna/gateware/applets/speed_test.py
+++ b/luna/gateware/applets/speed_test.py
@@ -15,10 +15,12 @@ BULK_ENDPOINT_NUMBER = 1
 class USBSpeedTestDevice(Elaboratable):
     """ Simple device that exchanges data with the host as fast as the hardware can. """
 
-    def __init__(self, generate_clocks=True, fs_only=False, phy=None, pid=PRODUCT_ID):
+    def __init__(self, generate_clocks=True, fs_only=False, phy=None,
+            vid=VENDOR_ID, pid=PRODUCT_ID):
         self.generate_clocks = generate_clocks
         self.fs_only = fs_only
         self.phy = phy
+        self.vid = vid
         self.pid = pid
         self.max_bulk_packet_size = 64 if fs_only else 512
 
@@ -34,7 +36,7 @@ class USBSpeedTestDevice(Elaboratable):
 
         # We'll need a device descriptor...
         with descriptors.DeviceDescriptor() as d:
-            d.idVendor           = VENDOR_ID
+            d.idVendor           = self.vid
             d.idProduct          = self.pid
 
             d.iManufacturer      = "LUNA"


### PR DESCRIPTION
This PR adds some optional constructor arguments to `USBSpeedTestDevice` that allow overriding the VID/PID, and disabling clock generation so that the code can be used as part of a larger design with its own clock arrangements.

Required by [cynthion-test](https://github.com/greatscottgadgets/cynthion-test), which builds a bitstream with the speed test gateware running on all three ports simultaneously.