### PR TITLE
Use Python 3.8 compatible type annotation for 'str | None'

### DIFF
--- a/luna/gateware/platform/__init__.py
+++ b/luna/gateware/platform/__init__.py
@@ -11,6 +11,8 @@ import logging
 import importlib
 import importlib.util
 
+from typing import Optional
+
 from amaranth import Record
 
 from .core import NullPin, LUNAPlatform
@@ -66,7 +68,7 @@ def get_appropriate_platform() -> LUNAPlatform:
     return platform
 
 
-def get_apollo_platform() -> str | None:
+def get_apollo_platform() -> Optional[str]:
     """ Attempts to return a platform string for a connected Apollo-based device. """
 
     # Try to import Apollo.


### PR DESCRIPTION
We've recently settled on Python 3.8 as our minimum supported Python version for releases.

Python 3.8 does not however support `str | None` syntax as it was only introduced in 3.10.

This PR uses `typing.Optional` instead.
