### PR TITLE
gateware: add string descriptor for retrieving Flash UID at runtime

### DIFF
--- a/luna/gateware/architecture/flash_sn.py
+++ b/luna/gateware/architecture/flash_sn.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+from amaranth import Mux, Cat, C
+
+from ..stream.generator  import StreamSerializer
+from ..usb.usb2.transfer import USBInStreamInterface
+from ..interface.flash   import ECP5ConfigurationFlashInterface, FlashUIDReader
+
+
+class ECP5FlashUIDStringDescriptor(StreamSerializer):
+    """ Custom runtime string descriptor that returns the Flash UID as a hex string. """
+
+    def __init__(self):
+        super().__init__(34, domain="usb", stream_type=USBInStreamInterface, max_length_width=16)
+
+    def elaborate(self, platform):
+        m = super().elaborate(platform)
+
+        # Create the required modules to retrieve the flash UID.
+        m.submodules.spi_bus  = spi_bus  = ECP5ConfigurationFlashInterface(bus=platform.request('spi_flash'), use_cs=True)
+        m.submodules.flashuid = flashuid = FlashUIDReader(bus=spi_bus)
+
+        # Helper function to convert a value to a hex string
+        def get_hex_char(value, index):
+            nibble = value.word_select(index ^ 1, 4)
+            return Mux(nibble > 9, nibble - 10 + ord('a'), Cat(nibble, C(0b11, 2)))
+
+        # Create string descriptor
+        m.d.comb += [
+            self.data[0].eq(self.data_length),
+            self.data[1].eq(3),  # string type
+        ]
+        for i in range(16):
+            m.d.comb += self.data[2+2*i].eq(get_hex_char(flashuid.uid, i))
+
+        return m

--- a/luna/gateware/interface/flash.py
+++ b/luna/gateware/interface/flash.py
@@ -6,7 +6,7 @@
 
 """ Interfaces for working with an ECP5 MSPI configuration flash. """
 
-from amaranth import Signal, Module, Cat, Elaboratable, Instance
+from amaranth import Signal, Module, Cat, Elaboratable, Instance, DomainRenamer, C
 
 
 class ECP5ConfigurationFlashInterface(Elaboratable):
@@ -52,19 +52,90 @@ class ECP5ConfigurationFlashInterface(Elaboratable):
 
         # Connect up each of our other signals.
         m.d.comb += [
-            self.bus.sdi   .eq(self.sdi),
-            self.sdo       .eq(self.bus.sdo)
+            self.bus.sdi.o .eq(self.sdi),
+            self.sdo       .eq(self.bus.sdo.i)
         ]
         
+        if self.use_cs:
+            m.d.comb += self.bus.cs.o.eq(self.cs)
         if hasattr(self.bus.cs, "oe"):
-            if self.use_cs:
+            m.d.comb += self.bus.cs.oe.eq(self.use_cs)
+        
+        return m
+
+
+class FlashUIDReader(Elaboratable):
+    """ Gateware that implements a simple SPI Flash unique ID reader, triggered on reset. 
+    
+    I/O ports:
+
+        B: bus  -- The SPI bus used to communicate with the device.
+        
+        O: uid  -- Contains the retrieved ID after the read is finished.
+        O: done -- A signal that gets asserted when the read operation finishes.
+    """
+
+    # Opcode to read the chip's unique ID.
+    READ_UID = 0x4B
+    
+    def __init__(self, bus, clock_period=4, domain="sync"):
+        assert clock_period & (clock_period - 1) == 0  # only powers of 2
+        self._domain = domain
+        self.period  = clock_period
+        self.bus     = bus
+
+        #
+        # I/O port
+        #
+        self.uid     = Signal(64)
+        self.done    = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # Clock generation and clock edge strobes
+        cycles   = Signal(range(self.period))
+        sck_fall = Signal()
+        sck_rise = Signal()
+        sck_d    = Signal()
+        m.d.sync += sck_d.eq(self.bus.sck)
+        m.d.comb += [
+            sck_fall.eq( sck_d & ~self.bus.sck),  # falling edge
+            sck_rise.eq(~sck_d &  self.bus.sck),  # rising edge
+        ]
+        
+        # Output shift register and bit counter
+        shreg_o = Signal(8, reset=self.READ_UID)
+        count_o = Signal(range(128), reset=8*(1+4+8)-1)  # bytes: 1 opcode, 4 padding, 8 id
+
+        with m.FSM(domain=self._domain):
+
+            with m.State("XFER"):
                 m.d.comb += [
-                    self.bus.cs.o.eq(self.cs),
-                    self.bus.cs.oe.eq(1)
+                    self.bus.sck .eq(cycles[-1]),
+                    self.bus.sdi .eq(shreg_o[-1]),
+                    self.bus.cs  .eq(1),
                 ]
-            else:
-                m.d.comb += self.bus.cs.oe.eq(0)
-        elif self.use_cs:
-            m.d.comb += self.bus.cs.eq(self.cs)
+                m.d.sync += cycles.eq(cycles + 1)
+
+                # Read logic: latch on rising edge
+                with m.If(sck_rise):
+                    m.d.sync += self.uid.eq(Cat(self.bus.sdo, self.uid[:-1]))
+
+                # Write logic: setup on falling edge
+                with m.If(sck_fall):
+                    m.d.sync += [
+                        shreg_o .eq(Cat(C(0,1), shreg_o[:-1])),
+                        count_o .eq(count_o - 1),
+                    ]
+                    with m.If(count_o == 0):
+                        m.next = 'END'
+            
+            with m.State("END"):
+                m.d.comb += self.done.eq(1)
+
+        # Convert our sync domain to the domain requested by the user, if necessary.
+        if self._domain != "sync":
+            m = DomainRenamer({"sync": self._domain})(m)
 
         return m


### PR DESCRIPTION
This PR adds the ability to use runtime / dynamic string descriptors that adhere to the `StreamSerializer` interface. 

The `ECP5FlashUIDStringDescriptor` module can be used to use the SPI Flash unique ID as a serial number for the device (hex-string): 
```python
d.iSerialNumber = ECP5FlashUIDStringDescriptor
```

This needs https://github.com/greatscottgadgets/python-usb-protocol/pull/31.