### PR TITLE
Add method to get Apollo port sharing method

### DIFF
--- a/luna/gateware/platform/core.py
+++ b/luna/gateware/platform/core.py
@@ -97,6 +97,10 @@ class LUNAPlatform:
 class LUNAApolloPlatform(LUNAPlatform):
     """ Base class for Apollo-based LUNA platforms; includes configuration. """
 
+    def port_sharing(self, phy_name):
+        sharing = getattr(self, "apollo_port_sharing", {})
+        return sharing.get(phy_name, None)
+
     def toolchain_program(self, products, name):
         """ Programs the relevant LUNA board via its sideband connection. """
 

--- a/luna/gateware/platform/core.py
+++ b/luna/gateware/platform/core.py
@@ -98,6 +98,24 @@ class LUNAApolloPlatform(LUNAPlatform):
     """ Base class for Apollo-based LUNA platforms; includes configuration. """
 
     def port_sharing(self, phy_name):
+        """ Reports whether and how the USB port for a given PHY is shared with Apollo.
+
+        Parameters
+        ----------
+        phy_name: str
+            The name of a PHY resource on the platform.
+
+        Returns
+        -------
+        A string identifying the sharing mechanism, or None if the port is not shared.
+
+        Supported sharing mechanisms are:
+
+        "advertising":
+            The gateware must create an ApolloAdvertiser instance, which will
+            signal to the Apollo MCU that it wishes to use the port. The FPGA
+            may hand the port back to Apollo by ceasing advertising.
+        """
         sharing = getattr(self, "apollo_port_sharing", {})
         return sharing.get(phy_name, None)
 


### PR DESCRIPTION
Adds a `port_sharing` method to `LUNAApolloPlatform` which checks the port sharing method for a given PHY name.