### PR TITLE
Limit pyproject include mask to just the main package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["*"]
+include = ["luna*"]
 
 [tool.pdm.scripts]
 test.cmd = "python -m unittest discover -t . -s tests -v"


### PR DESCRIPTION
This avoids including tests/examples and also any other build files that might be in the directory.