### PR TITLE
fixed cdc.py bug

### DIFF
--- a/luna/gateware/utils/cdc.py
+++ b/luna/gateware/utils/cdc.py
@@ -55,7 +55,7 @@ def synchronize(m, signal, *, output=None, o_domain='sync', stages=2):
     for name, layout, direction in signal.layout:
 
         # If this is a record itself, we'll need to recurse.
-        if isinstance(signal[name], (Record, Pin)):
+        if isinstance(signal[name], Record) and (len(layout.fields) > 1): 
             synchronize(m, signal[name], output=output[name],
                     o_domain=o_domain, stages=stages)
             continue


### PR DESCRIPTION
fixes https://github.com/greatscottgadgets/luna/issues/101.
You can test the issue by making the following on a fpga. This basically makes sdo equal to sdi.
```python
from amaranth import Elaboratable, Module
from luna.gateware.interface.spi import SPIDeviceInterface
from luna.gateware.utils.cdc import synchronize

from hexastorm.platforms import Firestarter


class DebugSPIExample(Elaboratable):
    """Hardware meant to demonstrate use of
    the Debug Controller's SPI interface copied from Luna"""

    def __init__(self):
        # Base ourselves around an SPI command interface.
        self.interface = SPIDeviceInterface(clock_phase=1)

    def elaborate(self, platform):
        m = Module()
        board_spi = platform.request("debug_spi")

        # Use command interface.
        m.submodules.interface = self.interface

        # Synchronize and connect SPI.
        spi = synchronize(m, board_spi)
        m.d.comb += self.interface.spi.connect(spi)

        # Turn on a single LED, to show something's running.
        led = platform.request("led", 0)
        m.d.comb += led.eq(1)

        # Echo back the last received data.
        m.d.comb += self.interface.word_out.eq(self.interface.word_in)

        return m
```
You then write bytes and see if you get them back. This is not the case with amaranth at the moment.
```python
import spidev
from gpiozero import LED

spi = spidev.SpiDev()
spi.open(0, 0)
spi.mode = 1
chip_select = LED(select_pin)
chip_select.on()
spi.max_speed_hz = round(1e6)
bts = [210, 222, 230]
previous_byte = None
for idx, byte in enumerate(bts):
    chip_select.off()
    byte_received = spi.xfer([byte])[0]
    chip_select.on()
    if idx != 0:
        try:
            assert previous_byte == byte_received
        except AssertionError:
            print(previous_byte)
            print(byte_received)
            raise Exception("Test failed: not equal")
    previous_byte = byte
```