### PR TITLE
gateware: fix an order-of-operations bug with cdc.synchronize

### DIFF
--- a/luna/gateware/utils/cdc.py
+++ b/luna/gateware/utils/cdc.py
@@ -55,8 +55,11 @@ def synchronize(m, signal, *, output=None, o_domain='sync', stages=2):
     for name, layout, direction in signal.layout:
         # Skip any output elements, as they're already
         # in our clock domain, and we don't want to drive them.
-        if (direction == DIR_FANOUT) or (hasattr(signal[name], 'o') and ~hasattr(signal[name], 'i')):
+        if (direction == DIR_FANOUT):
             m.d.comb += signal[name].eq(output[name])
+            continue
+        elif hasattr(signal[name], 'o') and ~hasattr(signal[name], 'i'):
+            m.d.comb += signal[name].o.eq(output[name])
             continue
 
         # If this is a record itself, we'll need to recurse.

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -8,6 +8,7 @@ from luna.gateware.test         import LunaGatewareTestCase, sync_test_case
 from unittest       import TestCase
 
 from amaranth import Module, Record, Signal
+from amaranth.lib.io import Pin
 from amaranth.hdl.rec import DIR_FANIN, DIR_FANOUT
 from luna.gateware.utils.cdc import synchronize, stretch_strobe_signal
 
@@ -37,6 +38,17 @@ class SynchronizedTest(TestCase):
                 ('subsig_out', 1, DIR_FANOUT),
             ])
         ])
+        synchronize(m, record)
+
+    def test_pins(self):
+        m = Module()
+        pins = {
+            "sig_in": Pin(1, "i"),
+            "sig_out": Pin(1, "o"),
+        }
+        record = Record([
+            (f_name, f.layout) for (f_name, f) in pins.items()
+        ], fields=pins)
         synchronize(m, record)
 
 


### PR DESCRIPTION
In https://github.com/greatscottgadgets/luna/commit/db754379448e606c4e80bb499ef052abcaec4183 a subtle bug was introduced into cdc.synchronize where nested elements of type `Pin` with directionality `output` would be recursed into and end up being driven by `FFSynchronizer` rather than being skipped.

This would result in the signal being driven from multiple fragments: once from the top-level design and again by the undesired `FFSynchronizer`.

Prior to this change this was not an issue as the recursion operation only applied to elements of type `Record`.

Moving the directionality check to occur prior to the recursive operation resolves the issue.