### PR TITLE
gateware.usb.request.standard: pass max packet size to GetDescriptor handler

### DIFF
--- a/luna/gateware/usb/request/standard.py
+++ b/luna/gateware/usb/request/standard.py
@@ -58,7 +58,7 @@ class StandardRequestHandler(ControlRequestHandler):
 
         # The distributed handler supports a combination of fixed and runtime descriptors directly...
         if self._avoid_blockram:
-            return GetDescriptorHandlerDistributed(self.descriptors)
+            return GetDescriptorHandlerDistributed(self.descriptors, max_packet_length=self._max_packet_size)
 
         # ...but the block handler does not. In this case, first we split the descriptors into two 
         # collections: fixed descriptors (for the ROM) and runtime descriptors. 
@@ -75,11 +75,11 @@ class StandardRequestHandler(ControlRequestHandler):
         # If there are runtime descriptors, we add a get descriptor multiplexer and a distributed handler.
         if has_runtime_descriptors:
             handler_mux = GetDescriptorHandlerMux()
-            handler_mux.add_descriptor_handler(GetDescriptorHandlerBlock(fixed_descriptors))
-            handler_mux.add_descriptor_handler(GetDescriptorHandlerDistributed(runtime_descriptors))
+            handler_mux.add_descriptor_handler(GetDescriptorHandlerBlock(fixed_descriptors, max_packet_length=self._max_packet_size))
+            handler_mux.add_descriptor_handler(GetDescriptorHandlerDistributed(runtime_descriptors, max_packet_length=self._max_packet_size))
             return handler_mux
         else:
-            return GetDescriptorHandlerBlock(self.descriptors)
+            return GetDescriptorHandlerBlock(self.descriptors, max_packet_length=self._max_packet_size)
 
 
     def elaborate(self, platform):


### PR DESCRIPTION
Previously, enumeration would fail on a low-speed device:
```
[77942.213251] usb 2-2: new low-speed USB device number 106 using xhci_hcd
[77942.341327] usb 2-2: device descriptor read/64, error -75
[77942.577321] usb 2-2: device descriptor read/64, error -75
```
which translates to `EOVERFLOW 75 Value too large for defined data type.`
 
Looking on the scope, we found that the device was trying to return a longer packet than allowed for GetDescriptor requests:

![hil-lowspeed-scope](https://github.com/greatscottgadgets/luna/assets/578095/97c71a06-e378-4bdb-96ab-1c1d785852bd)

This change makes sure to pass the max packet size through to the handler to set the limit correctly.