### PR TITLE
gateware.platform: Use force_fpga_offline()

### DIFF
--- a/luna/gateware/platform/core.py
+++ b/luna/gateware/platform/core.py
@@ -151,9 +151,7 @@ class LUNAApolloPlatform(LUNAPlatform):
 
         from apollo_fpga.ecp5 import ECP5_JTAGProgrammer
 
-        with debugger.jtag as jtag:
-            programmer = ECP5_JTAGProgrammer(jtag)
-            programmer.unconfigure()
+        debugger.force_fpga_offline()
 
 
     def toolchain_flash(self, products, name="top"):


### PR DESCRIPTION
This avoids a minor indication bug (https://github.com/greatscottgadgets/apollo/issues/108).