### PR TITLE
gateware.usb.usb2.device: Enable HS transfer with custom UTMI

### DIFF
--- a/luna/gateware/usb/usb2/device.py
+++ b/luna/gateware/usb/usb2/device.py
@@ -119,8 +119,8 @@ class USBDevice(Elaboratable):
             self.utmi       = bus
             self.bus_busy   = Const(0)
             self.translator = None
-            self.always_fs  = True
-            self.data_clock = 12e6
+            self.always_fs  = False
+            self.data_clock = 60e6
 
         #
         # I/O port


### PR DESCRIPTION
Removes Full Speed limitation when using custom UTMI PHY. Bump the associated clock to 60 MHz (required for achieving 480Mbps throughput).

Fixes #276