### PR TITLE
Add support for using yowasp when yosys is not available.

### DIFF
--- a/luna/__init__.py
+++ b/luna/__init__.py
@@ -12,6 +12,8 @@ import argparse
 from amaranth           import Elaboratable
 from amaranth._unused   import MustUse
 
+from luna.gateware.platform import configure_toolchain
+
 # Log formatting strings.
 LOG_FORMAT_COLOR = "\u001b[37;1m%(levelname)-8s| \u001b[0m\u001b[1m%(module)-12s|\u001b[0m %(message)s"
 LOG_FORMAT_PLAIN = "%(levelname)-8s:n%(module)-12s>%(message)s"
@@ -108,8 +110,15 @@ def top_level_cli(fragment, *pos_args, **kwargs):
         join_text = "and uploading gateware to attached" if args.upload else "for"
         logging.info(f"Building {join_text} {platform.name}...")
 
+        # Configure toolchain.
+        if not configure_toolchain(platform):
+            logging.info(f"Failed to configure the toolchain for: {platform.toolchain}")
+            logging.info(f"Continuing anyway.")
+
         # Now that we're actually building, re-enable Unused warnings.
         MustUse._MustUse__silence = False
+
+        # Perform the build.
         products = platform.build(fragment,
             do_program=args.upload,
             build_dir=build_dir

--- a/luna/gateware/platform/__init__.py
+++ b/luna/gateware/platform/__init__.py
@@ -16,6 +16,7 @@ from typing import Optional
 from amaranth import Record
 
 from .core import NullPin, LUNAPlatform
+from .toolchain import configure_toolchain
 
 
 def _get_platform_from_string(platform):
@@ -63,11 +64,11 @@ def get_appropriate_platform() -> LUNAPlatform:
             "Unable to autodetect a supported platform. "
             "The LUNA_PLATFORM environment variable must be set.")
     platform = _get_platform_from_string(platform_string)
-    
+
     # If possible, override the platform's device type with the detected FPGA.
     if fpga_device is not None:
         platform.device = fpga_device
-    
+
     return platform
 
 

--- a/luna/gateware/platform/toolchain.py
+++ b/luna/gateware/platform/toolchain.py
@@ -1,0 +1,72 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2020-2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+""" Utilities for managing LUNA gateware toolchains. """
+
+import importlib
+import logging
+import os
+import shutil
+
+def configure_toolchain(platform):
+    """ Checks if all the required tools for the Yosys toolchain are available.
+
+        If there are missing tools it will attempt to fall back to YoWASP instead.
+
+        Returns:
+            True if a valid toolchain has been configured. Otherwise False.
+    """
+
+    if platform.has_required_tools():
+        # All good, no further hanky-panky required.
+        return True
+
+    # Do we have yowasp available to us?
+    logging.info(f"Failed to locate {platform.toolchain} toolchain, trying YoWASP.")
+    logging.debug("Checking for required tools:")
+    for tool in platform.required_tools:
+        logging.debug(f"    {tool}")
+
+    problems = 0
+
+    # Check whether yowasp-yosys is installed:
+    try:
+        import yowasp_yosys
+        logging.debug(f"Found module: {yowasp_yosys.__name__}")
+    except Exception as e:
+        problems += 1
+        logging.warning(e)
+
+    # Check whether yowasp-nextpnr-<target> is installed:
+    try:
+        nextpnr = next(filter(lambda x: x.startswith("nextpnr-"), platform.required_tools))
+        yowasp_nextpnr = importlib.import_module("yowasp_" + nextpnr.replace('-', '_'))
+        logging.debug(f"Found module: {yowasp_nextpnr.__name__}")
+    except Exception as e:
+        problems += 1
+        logging.warning(e)
+
+    # Check whether the YoWASP binaries are on the system PATH:
+    for tool in platform.required_tools:
+        env_var     = tool.replace('-', '_').upper()
+        yowasp_tool = "yowasp-" + tool
+        path = shutil.which(yowasp_tool)
+        if not path:
+            problems += 1
+            logging.warning(f"'{yowasp_tool}' is not on the system PATH.")
+        else:
+            logging.debug(f'Setting {env_var}="{yowasp_tool}"')
+            os.environ[env_var] = yowasp_tool
+
+    if problems == 0:
+        logging.info("YoWASP configured successfully.")
+    else:
+        logging.info(f"{problems} problems encountered while configuring YoWASP.")
+        logging.info(f"You can install it with:")
+        logging.info(f"    pip install yowasp-yosys yowasp-{nextpnr}")
+        return False
+
+    return True


### PR DESCRIPTION
While YosysHQ's OSS CAD Suite distribution is readily available it can be somewhat overwhelming to install for beginners.

To make it easier for readers of our gateware tutorials this PR adds support to LUNA for using [YoWASP](https://yowasp.org/)'s WASM-based packages for Yosys and NextPNR if there aren't any other Amaranth-supported toolchains available.

The logic works as follows:

1. Check if platform has all required tools with `platform.has_required_tools()`. If it has, do nothing further and continue to the build.
2. Otherwise, start by setting the `problem` count to `0` and then:
3. Check if the following Python modules can be imported, incrementing the problem count if it cannot.
  - `yowasp_yosys`
  - `yowasp_nextpnr-<target>` where `<target>` is obtained from `platform.required_tools`.
4. Check if the tool binaries are abailable on the system `PATH`:
  - If it is found, set the environment variable for `TOOL_NAME` to `yowasp-tool-name` so that Amaranth will use the YoWASP binary instead of he Yosys binary.
  - Otherwise, increment the problem count.
5. If the problem count is zero, return and continue to the build.
6. If the problem count is non-zero output a helpful message and continue to the build anyway. (The build could still succeed anyway if someone is using a strange or unusual toolchain.)
