### PR TITLE
Don't limit handle_register_write_request helper to 7 bits

### DIFF
--- a/luna/gateware/usb/request/control.py
+++ b/luna/gateware/usb/request/control.py
@@ -37,7 +37,7 @@ class ControlRequestHandler(USBRequestHandler):
         with m.If(self.interface.handshakes_in.ack):
             m.d.comb += [
                 write_strobe      .eq(1),
-                new_value_signal  .eq(self.interface.setup.value[0:7])
+                new_value_signal  .eq(self.interface.setup.value)
             ]
 
             # ... and then return to idle.


### PR DESCRIPTION
This is a leftover from when this was part of StandardRequestHandler. We can just remove the restriction; if the destination is narrower than the 16-bit value in the request it will be truncated anyway.