### PR TITLE
gateware.usb2.packet: Fix fanout direction

### DIFF
--- a/luna/gateware/usb/usb2/packet.py
+++ b/luna/gateware/usb/usb2/packet.py
@@ -48,7 +48,7 @@ class HandshakeExchangeInterface(Record):
     """
 
     def __init__(self, *, is_detector):
-        direction = DIR_FANOUT if is_detector else DIR_FANOUT
+        direction = DIR_FANOUT if is_detector else DIR_FANIN
 
         super().__init__([
             ('ack',   1, direction),

--- a/luna/gateware/usb/usb2/request.py
+++ b/luna/gateware/usb/usb2/request.py
@@ -88,8 +88,8 @@ class RequestHandlerInterface:
         self.rx_invalid            = Signal()
 
         self.tx                    = USBInStreamInterface()
-        self.handshakes_out        = HandshakeExchangeInterface(is_detector=True)
-        self.handshakes_in         = HandshakeExchangeInterface(is_detector=False)
+        self.handshakes_out        = HandshakeExchangeInterface(is_detector=False)
+        self.handshakes_in         = HandshakeExchangeInterface(is_detector=True)
         self.tx_data_pid           = Signal(init=1)
 
 


### PR DESCRIPTION
HandshakeExchangeInterface was always exposing its interface as fanout, no matter the value of is_director. USBInTransferManager was affected by this bug, as the is_director configuration was inverted.