### PR TITLE
USB3: Implement compliance mode, de-emphasis, and tune TX amplitude on ECP5

### DIFF
--- a/luna/gateware/interface/pipe.py
+++ b/luna/gateware/interface/pipe.py
@@ -8,6 +8,7 @@
 
 from amaranth import *
 from amaranth.lib.cdc  import FFSynchronizer, ResetSynchronizer
+from amaranth.lib.enum import IntEnum
 from amaranth.lib.fifo import AsyncFIFOBuffered
 
 
@@ -156,7 +157,7 @@ class PIPEInterface(Elaboratable):
         self.elas_buf_mode  = Signal(1)
         self.rate           = Signal(1)
         self.power_down     = Signal(2)
-        self.tx_deemph      = Signal(2)
+        self.tx_deemph      = Signal(TXDeemphMode)
         self.tx_margin      = Signal(3)
         self.tx_swing       = Signal(1)
         self.tx_detrx_lpbk  = Signal()
@@ -561,3 +562,8 @@ class GearedPIPEInterface(Elaboratable):
         return m
 
 
+class TXDeemphMode(IntEnum, shape=2):
+    DEEMPH_6DB      = 0b00
+    DEEMPH_3P5DB    = 0b01
+    DEEMPH_NONE     = 0b10
+    DEEMPH_RESERVED = 0b11

--- a/luna/gateware/interface/pipe.py
+++ b/luna/gateware/interface/pipe.py
@@ -89,8 +89,8 @@ class PIPEInterface(Elaboratable):
     tx_compliance : Signal(), input
         If asserted, sets the running disparity to negative for the first symbol on the transmit
         data bus. This signal is implemented only for PHYs that can operate in the PCI Express mode.
-    tx_ones_zeroes : Signal(), input
-        If asserted, the PHY transmits an alternating sequence of 50-250 ones and 50-250 zeroes
+    tx_ones_zeros : Signal(), input
+        If asserted, the PHY transmits an alternating sequence of 50-250 ones and 50-250 zeros
         instead of the data on the transmit data bus. This signal is implemented only for PHYs
         that can operate in the SuperSpeed USB mode.
     rx_polarity : Signal(), input
@@ -162,7 +162,7 @@ class PIPEInterface(Elaboratable):
         self.tx_detrx_lpbk  = Signal()
         self.tx_elec_idle   = Signal()
         self.tx_compliance  = Signal()
-        self.tx_ones_zeroes = Signal()
+        self.tx_ones_zeros  = Signal()
         self.rx_polarity    = Signal()
         self.rx_eq_training = Signal()
         self.rx_termination = Signal()
@@ -252,20 +252,20 @@ class AsyncPIPEInterface(PIPEInterface, Elaboratable):
         geared_tx_data          = Signal.like(self.tx_data)
         geared_tx_datak         = Signal.like(self.tx_datak)
         geared_tx_compliance    = Signal.like(self.tx_compliance)
-        geared_tx_ones_zeroes   = Signal.like(self.tx_ones_zeroes)
+        geared_tx_ones_zeros    = Signal.like(self.tx_ones_zeros)
         mac_tx_bus_signals = Cat(
             self.tx_data,
             self.tx_datak,
             # These control signals are additional inputs to the 8b10b encoder; and must be
             # exactly synchronized to the transmit data bus.
             self.tx_compliance,
-            self.tx_ones_zeroes,
+            self.tx_ones_zeros,
         )
         phy_tx_bus_signals = Cat(
             geared_tx_data,
             geared_tx_datak,
             geared_tx_compliance,
-            geared_tx_ones_zeroes,
+            geared_tx_ones_zeros,
         )
 
         m.d.comb += [
@@ -275,8 +275,8 @@ class AsyncPIPEInterface(PIPEInterface, Elaboratable):
         # TxCompliance affects only the first transmitted symbol; keep that property after gearing.
         with m.If(gear_index == 0):
             m.d.comb += phy.tx_compliance   .eq(geared_tx_compliance)
-        # TxOnesZeroes replaces all symbols on the transmit data bus.
-        m.d.comb += phy.tx_ones_zeroes  .eq(geared_tx_ones_zeroes)
+        # TxOnesZeros replaces all symbols on the transmit data bus.
+        m.d.comb += phy.tx_ones_zeros  .eq(geared_tx_ones_zeros)
 
         m.submodules.tx_fifo = tx_fifo = AsyncFIFOBuffered(
             width=len(mac_tx_bus_signals),

--- a/luna/gateware/interface/serdes_phy/ecp5.py
+++ b/luna/gateware/interface/serdes_phy/ecp5.py
@@ -113,6 +113,7 @@ class ECP5SerDesRegisterTranslator(Elaboratable):
         #
         # I/O port
         #
+        self.enc_bypass  = Signal()
         self.loopback    = Signal()
         self.rx_polarity = Signal()
         self.tx_idle     = Signal()
@@ -187,6 +188,35 @@ class ECP5SerDesRegisterTranslator(Elaboratable):
                     sci.adr.eq(0x02),
                     sci.dat_w.eq(data),
                     sci.dat_w[6].eq(self.tx_idle),  # pcie_ei_en
+                ]
+
+                with m.If(~first & sci.done):
+                    m.d.pipe += first.eq(1)
+                    m.d.comb += sci.we.eq(0)
+                    m.next = "READ-CH_03"
+
+            with m.State("READ-CH_03"):
+                m.d.pipe += first.eq(0)
+                m.d.comb += [
+                    sci.chan_sel.eq(1),
+                    sci.re.eq(1),
+                    sci.adr.eq(0x03),
+                ]
+
+                with m.If(~first & sci.done):
+                    m.d.comb += sci.re.eq(0)
+                    m.d.pipe += first.eq(1)
+                    m.d.pipe += data.eq(sci.dat_r)
+                    m.next = "WRITE-CH_03"
+
+            with m.State("WRITE-CH_03"):
+                m.d.pipe += first.eq(0)
+                m.d.comb += [
+                    sci.chan_sel.eq(1),
+                    sci.we.eq(1),
+                    sci.adr.eq(0x03),
+                    sci.dat_w.eq(data),
+                    sci.dat_w[3].eq(self.enc_bypass),  # enc_bypass
                 ]
 
                 with m.If(~first & sci.done):

--- a/luna/gateware/interface/serdes_phy/ecp5.py
+++ b/luna/gateware/interface/serdes_phy/ecp5.py
@@ -1157,6 +1157,7 @@ class ECP5SerDesPIPE(PIPEInterface, Elaboratable):
             pll_config  = pll_config,
             tx_pads     = self._tx_pads,
             rx_pads     = self._rx_pads,
+            dual        = self._dual,
             channel     = self._channel,
         )
 

--- a/luna/gateware/interface/serdes_phy/ecp5.py
+++ b/luna/gateware/interface/serdes_phy/ecp5.py
@@ -725,6 +725,7 @@ class ECP5SerDes(Elaboratable):
         self.rx_datak       = Signal(self._io_words)
 
         # TX controls
+        self.tx_ones_zeros  = Signal()
         self.tx_polarity    = Signal()
         self.tx_elec_idle   = Signal()
         self.tx_gpio_en     = Signal()
@@ -793,6 +794,7 @@ class ECP5SerDes(Elaboratable):
         m.submodules.sci = sci = ECP5SerDesConfigInterface(self)
         m.submodules.sci_trans = sci_trans = ECP5SerDesRegisterTranslator(self, sci)
         m.d.comb += [
+            sci_trans.enc_bypass    .eq(self.tx_ones_zeros),
             sci_trans.tx_polarity   .eq(self.tx_polarity),
             sci_trans.rx_polarity   .eq(self.rx_polarity),
             sci_trans.rx_termination.eq(self.rx_termination),
@@ -1114,6 +1116,21 @@ class ECP5SerDes(Elaboratable):
             tx_bus[20]          .eq(self.tx_datak[1]),
         ]
 
+        # If `tx_ones_zeros` is set, override the TX data.
+        tx_pattern = Signal.like(tx_bus)
+        counter = Signal(range(9))
+        m.d.pipe += [
+            counter.eq(counter + 1),
+            # When bypassing the 8b10b encoder, the bus expands to 10-bit.
+            # However, we're still in PCIe mode and need to avoid setting `pcie_ei_en`.
+            # (table 7.3 in the user guide is not very clear on this case)
+            tx_pattern[0 :10].eq(Mux(counter[-1], -1, 0)),
+            tx_pattern[12:22].eq(Mux(counter[-1], -1, 0)),
+        ]
+        with m.If(self.tx_ones_zeros):
+            m.d.comb += tx_bus.eq(tx_pattern)
+
+
         # The SerDes is providing us with two RxStatus words, one per byte; but we emit only one
         # for the entire word. Combine the status conditions together according to their priorities.
         for rx_status_code in 0b011, 0b010, 0b001, 0b111, 0b110, 0b101, 0b100:
@@ -1154,8 +1171,9 @@ class ECP5SerDesPIPE(PIPEInterface, Elaboratable):
     tx_detrx_lpbk :
     tx_elec_idle :
         Transmit control signals. Loopback and receiver detection are not implemented.
-    tx_compliance :
     tx_ones_zeros :
+        Transmit 50-250 ones and 50-250 zeros. This implementation transmits 160 of each.
+    tx_compliance :
     rx_eq_training :
         These inputs are not implemented.
     power_present :
@@ -1219,6 +1237,7 @@ class ECP5SerDesPIPE(PIPEInterface, Elaboratable):
             self.pclk               .eq(serdes.pclk),
 
             serdes.tx_elec_idle     .eq(self.tx_elec_idle),
+            serdes.tx_ones_zeros    .eq(self.tx_ones_zeros),
             serdes.rx_polarity      .eq(self.rx_polarity),
             serdes.rx_termination   .eq(self.rx_termination),
             lfps_generator.generate .eq(self.tx_detrx_lpbk & self.tx_elec_idle),

--- a/luna/gateware/interface/serdes_phy/ecp5.py
+++ b/luna/gateware/interface/serdes_phy/ecp5.py
@@ -1155,7 +1155,7 @@ class ECP5SerDesPIPE(PIPEInterface, Elaboratable):
     tx_elec_idle :
         Transmit control signals. Loopback and receiver detection are not implemented.
     tx_compliance :
-    tx_ones_zeroes :
+    tx_ones_zeros :
     rx_eq_training :
         These inputs are not implemented.
     power_present :

--- a/luna/gateware/interface/serdes_phy/ecp5.py
+++ b/luna/gateware/interface/serdes_phy/ecp5.py
@@ -1078,10 +1078,10 @@ class ECP5SerDes(Elaboratable):
             p_CHX_TXAMPLITUDE       = "0d1000", # 1000 mV
 
             # CHX TX — equalization
-            p_CHX_TDRV_SLICE0_CUR   = "0b000",  # 200 uA
-            p_CHX_TDRV_SLICE0_SEL   = "0b00",   # power down
+            p_CHX_TDRV_SLICE0_CUR   = "0b001",  # 200 uA
+            p_CHX_TDRV_SLICE0_SEL   = "0b01",   # main data
 
-            p_CHX_TDRV_SLICE1_CUR   = "0b000",  # 200 uA
+            p_CHX_TDRV_SLICE1_CUR   = "0b000",  # 100 uA
             p_CHX_TDRV_SLICE1_SEL   = "0b00",   # power down
 
             # This slice will be switched to post data by SCI when de-emphasis is enabled.
@@ -1094,7 +1094,7 @@ class ECP5SerDes(Elaboratable):
             p_CHX_TDRV_SLICE4_CUR   = "0b11",   # 3200 uA
             p_CHX_TDRV_SLICE4_SEL   = "0b01",   # main data
 
-            p_CHX_TDRV_SLICE5_CUR   = "0b10",   # 2400 uA
+            p_CHX_TDRV_SLICE5_CUR   = "0b01",   # 1600 uA
             p_CHX_TDRV_SLICE5_SEL   = "0b01",   # main data
 
             p_CHX_TDRV_PRE_EN       = "0b0",

--- a/luna/gateware/interface/serdes_phy/ecp5.py
+++ b/luna/gateware/interface/serdes_phy/ecp5.py
@@ -17,7 +17,7 @@ from amaranth import *
 from amaranth.lib.cdc import FFSynchronizer
 
 from .lfps         import LFPSSquareWaveGenerator, LFPSSquareWaveDetector
-from ..pipe        import PIPEInterface
+from ..pipe        import PIPEInterface, TXDeemphMode
 
 
 class ECP5SerDesPLLConfiguration:
@@ -116,6 +116,7 @@ class ECP5SerDesRegisterTranslator(Elaboratable):
         self.enc_bypass  = Signal()
         self.loopback    = Signal()
         self.rx_polarity = Signal()
+        self.tx_deemph   = Signal(TXDeemphMode)
         self.tx_idle     = Signal()
         self.tx_polarity = Signal()
         self.rx_termination = Signal()
@@ -204,8 +205,8 @@ class ECP5SerDesRegisterTranslator(Elaboratable):
                 ]
 
                 with m.If(~first & sci.done):
-                    m.d.comb += sci.re.eq(0)
                     m.d.pipe += first.eq(1)
+                    m.d.comb += sci.re.eq(0)
                     m.d.pipe += data.eq(sci.dat_r)
                     m.next = "WRITE-CH_03"
 
@@ -217,6 +218,38 @@ class ECP5SerDesRegisterTranslator(Elaboratable):
                     sci.adr.eq(0x03),
                     sci.dat_w.eq(data),
                     sci.dat_w[3].eq(self.enc_bypass),  # enc_bypass
+                ]
+
+                with m.If(~first & sci.done):
+                    m.d.pipe += first.eq(1)
+                    m.d.comb += sci.we.eq(0)
+                    m.next = "READ-CH_12"
+
+            with m.State("READ-CH_12"):
+                m.d.pipe += first.eq(0)
+                m.d.comb += [
+                    sci.chan_sel.eq(1),
+                    sci.re.eq(1),
+                    sci.adr.eq(0x12),
+                ]
+
+                with m.If(~first & sci.done):
+                    m.d.comb += sci.re.eq(0)
+                    m.d.pipe += first.eq(1)
+                    m.d.pipe += data.eq(sci.dat_r)
+                    m.next = "WRITE-CH_12"
+
+            with m.State("WRITE-CH_12"):
+                m.d.pipe += first.eq(0)
+                # If de-emphasis is enabled, drive one slice with Post Data,
+                # else drive it with Main Data.
+                slice2_sel = Mux(self.tx_deemph == TXDeemphMode.DEEMPH_3P5DB, 0b11, 0b01)
+                m.d.comb += [
+                    sci.chan_sel.eq(1),
+                    sci.we.eq(1),
+                    sci.adr.eq(0x12),
+                    sci.dat_w.eq(data),
+                    sci.dat_w[4:6].eq(slice2_sel),
                 ]
 
                 with m.If(~first & sci.done):
@@ -250,6 +283,7 @@ class ECP5SerDesRegisterTranslator(Elaboratable):
                     m.d.comb += sci.dat_w[0:6].eq(0b110010) # lb_ctl
 
                 with m.If(~first & sci.done):
+                    m.d.pipe += first.eq(1)
                     m.d.comb += sci.we.eq(0)
                     m.next = "READ-CH_17"
 
@@ -725,6 +759,7 @@ class ECP5SerDes(Elaboratable):
         self.rx_datak       = Signal(self._io_words)
 
         # TX controls
+        self.tx_deemph      = Signal(TXDeemphMode)
         self.tx_ones_zeros  = Signal()
         self.tx_polarity    = Signal()
         self.tx_elec_idle   = Signal()
@@ -789,12 +824,17 @@ class ECP5SerDes(Elaboratable):
         # SerDes parameter control.
         #
 
+        # Disable de-emphasis when using the low-data-rate mode,
+        # to avoid an issue where the high-speed data still affects the output driver.
+        tx_deemph = Mux(self.tx_gpio_en, TXDeemphMode.DEEMPH_NONE, self.tx_deemph)
+
         # Some of the SerDes parameters cannot be directly controlled with fabric signals, but have to
         # be configured through the SerDes client interface.
         m.submodules.sci = sci = ECP5SerDesConfigInterface(self)
         m.submodules.sci_trans = sci_trans = ECP5SerDesRegisterTranslator(self, sci)
         m.d.comb += [
             sci_trans.enc_bypass    .eq(self.tx_ones_zeros),
+            sci_trans.tx_deemph     .eq(tx_deemph),
             sci_trans.tx_polarity   .eq(self.tx_polarity),
             sci_trans.rx_polarity   .eq(self.rx_polarity),
             sci_trans.rx_termination.eq(self.rx_termination),
@@ -1038,18 +1078,27 @@ class ECP5SerDes(Elaboratable):
             p_CHX_TXAMPLITUDE       = "0d1000", # 1000 mV
 
             # CHX TX — equalization
-            p_CHX_TDRV_SLICE0_CUR   = "0b011",  # 400 uA
-            p_CHX_TDRV_SLICE0_SEL   = "0b01",   # main data
-            p_CHX_TDRV_SLICE1_CUR   = "0b000",  # 100 uA
+            p_CHX_TDRV_SLICE0_CUR   = "0b000",  # 200 uA
+            p_CHX_TDRV_SLICE0_SEL   = "0b00",   # power down
+
+            p_CHX_TDRV_SLICE1_CUR   = "0b000",  # 200 uA
             p_CHX_TDRV_SLICE1_SEL   = "0b00",   # power down
-            p_CHX_TDRV_SLICE2_CUR   = "0b11",   # 3200 uA
+
+            # This slice will be switched to post data by SCI when de-emphasis is enabled.
+            p_CHX_TDRV_SLICE2_CUR   = "0b01",   # 1600 uA
             p_CHX_TDRV_SLICE2_SEL   = "0b01",   # main data
-            p_CHX_TDRV_SLICE3_CUR   = "0b10",   # 2400 uA
+
+            p_CHX_TDRV_SLICE3_CUR   = "0b11",   # 3200 uA
             p_CHX_TDRV_SLICE3_SEL   = "0b01",   # main data
-            p_CHX_TDRV_SLICE4_CUR   = "0b00",   # 800 uA
-            p_CHX_TDRV_SLICE4_SEL   = "0b00",   # power down
-            p_CHX_TDRV_SLICE5_CUR   = "0b00",   # 800 uA
-            p_CHX_TDRV_SLICE5_SEL   = "0b00",   # power down
+
+            p_CHX_TDRV_SLICE4_CUR   = "0b11",   # 3200 uA
+            p_CHX_TDRV_SLICE4_SEL   = "0b01",   # main data
+
+            p_CHX_TDRV_SLICE5_CUR   = "0b10",   # 2400 uA
+            p_CHX_TDRV_SLICE5_SEL   = "0b01",   # main data
+
+            p_CHX_TDRV_PRE_EN       = "0b0",
+            p_CHX_TDRV_POST_EN      = "0b1",
 
             # CHX TX — clocking
             p_CHX_FF_TX_F_CLK_DIS   = "0b0",    # enable  DIV/1 output clock
@@ -1236,6 +1285,7 @@ class ECP5SerDesPIPE(PIPEInterface, Elaboratable):
             serdes.reset            .eq(self.reset),
             self.pclk               .eq(serdes.pclk),
 
+            serdes.tx_deemph        .eq(self.tx_deemph),
             serdes.tx_elec_idle     .eq(self.tx_elec_idle),
             serdes.tx_ones_zeros    .eq(self.tx_ones_zeros),
             serdes.rx_polarity      .eq(self.rx_polarity),

--- a/luna/gateware/interface/serdes_phy/xc7_gtp.py
+++ b/luna/gateware/interface/serdes_phy/xc7_gtp.py
@@ -959,7 +959,7 @@ class XC7GTPSerDesPIPE(PIPEInterface, Elaboratable):
     tx_elec_idle :
         Transmit control signals. Loopback and receiver detection are not implemented.
     tx_compliance :
-    tx_ones_zeroes :
+    tx_ones_zeros :
         These inputs are not implemented.
     power_present :
         This output is not implemented. External logic may drive it if necessary.

--- a/luna/gateware/interface/serdes_phy/xc7_gtx.py
+++ b/luna/gateware/interface/serdes_phy/xc7_gtx.py
@@ -1017,7 +1017,7 @@ class XC7GTXSerDesPIPE(PIPEInterface, Elaboratable):
     tx_elec_idle :
         Transmit control signals. Loopback and receiver detection are not implemented.
     tx_compliance :
-    tx_ones_zeroes :
+    tx_ones_zeros :
         These inputs are not implemented.
     power_present :
         This output is not implemented. External logic may drive it if necessary.

--- a/luna/gateware/usb/usb3/link/compliance.py
+++ b/luna/gateware/usb/usb3/link/compliance.py
@@ -1,0 +1,80 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2026 Great Scott Gadgets <info@greatscottgadgets.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+""" Compliance pattern generation gateware.
+"""
+
+from collections import namedtuple
+
+from amaranth import *
+
+from ..physical.coding import NamedSymbol, D, K, COM, IDL
+from ...stream         import USBRawSuperSpeedStream
+
+Pattern = namedtuple(
+    'Pattern',
+    ['value', 'ctrl', 'scrambling', 'lfps', 'deemphasis', 'oneszeros'],
+    defaults=[0, 0, False, False, True, False],
+)
+
+PATTERNS = [
+    Pattern(IDL.value, IDL.ctrl, scrambling=True), # CP0: D0.0 scrambled
+    Pattern(D(10, 2)),                             # CP1: Nyquist frequency
+    Pattern(D(24, 3)),                             # CP2: Nyquist/2
+    Pattern(COM.value, COM.ctrl),                  # CP3: COM pattern
+    Pattern(lfps=True),                            # CP4: LFPS
+    Pattern(K(27, 7), ctrl=1),                     # CP5: K27.7 with de-emphasis
+    Pattern(K(27, 7), ctrl=1, deemphasis=False),   # CP6: K27.7 without de-emphasis
+    Pattern(oneszeros=True),                       # CP7: 50-250 ones & 50-250 zeros with de-emphasis
+    Pattern(oneszeros=True, deemphasis=False),     # CP8: 50-250 ones & 50-250 zeros without de-emphasis
+]
+
+
+class CompliancePatternEmitter(Elaboratable):
+    """ Emitter for USB3 physical layer compliance test patterns.
+    """
+    def __init__(self):
+
+        #
+        # I/O port
+        #
+        self.source             = USBRawSuperSpeedStream()
+
+        self.enable             = Signal()
+        self.enable_scrambling  = Signal()
+        self.lfps_ping_detected = Signal()
+        self.send_lfps_polling  = Signal()
+        self.disable_deemph     = Signal()
+        self.tx_ones_zeros      = Signal()
+
+
+
+    def elaborate(self, platform):
+        m = Module()
+
+        current_pattern = Signal(range(len(PATTERNS)))
+
+        with m.If(self.lfps_ping_detected):
+            m.d.sync += current_pattern.eq(current_pattern + 1)
+            with m.If(current_pattern == len(PATTERNS) - 1):
+                m.d.sync += current_pattern.eq(0)
+
+        with m.Switch(current_pattern):
+            for i, pattern in enumerate(PATTERNS):
+                with m.Case(i):
+                    with m.If(self.enable):
+                        m.d.comb += [
+                            self.source.valid     .eq(1),
+                            self.source.data      .eq(C(pattern.value, 8).replicate(4)),
+                            self.source.ctrl      .eq(C(pattern.ctrl,  1).replicate(4)),
+                            self.enable_scrambling.eq(pattern.scrambling),
+                            self.send_lfps_polling.eq(pattern.lfps),
+                            self.disable_deemph   .eq(~pattern.deemphasis),
+                            self.tx_ones_zeros    .eq(pattern.oneszeros),
+                        ]
+
+        return m
+

--- a/luna/gateware/usb/usb3/link/layer.py
+++ b/luna/gateware/usb/usb3/link/layer.py
@@ -18,6 +18,7 @@ from .transmitter  import PacketTransmitter
 from .timers       import LinkMaintenanceTimers
 from .ordered_sets import TSTransceiver
 from .data         import DataPacketReceiver, DataPacketTransmitter, DataHeaderPacket
+from .compliance   import CompliancePatternEmitter
 
 
 class USB3LinkLayer(Elaboratable):
@@ -63,6 +64,7 @@ class USB3LinkLayer(Elaboratable):
 
         # Test and debug signals.
         self.disable_scrambling        = Signal()
+        self.enable_compliance         = Signal()
 
 
     def elaborate(self, platform):
@@ -71,6 +73,11 @@ class USB3LinkLayer(Elaboratable):
 
         # Mark ourselves as always consuming physical-layer packets.
         m.d.comb += physical_layer.source.ready.eq(1)
+
+        #
+        # Compliance pattern generation
+        #
+        m.submodules.compliance_emitter = compliance_emitter = CompliancePatternEmitter()
 
         #
         # Training Set Detectors/Emitters
@@ -126,7 +133,7 @@ class USB3LinkLayer(Elaboratable):
 
             # LFPS control.
             ltssm.lfps_polling_detected          .eq(physical_layer.lfps_polling_detected),
-            physical_layer.send_lfps_polling     .eq(ltssm.send_lfps_polling),
+            physical_layer.send_lfps_polling     .eq(ltssm.send_lfps_polling | compliance_emitter.send_lfps_polling),
             ltssm.lfps_cycles_sent               .eq(physical_layer.lfps_cycles_sent),
 
             # Training set detectors
@@ -162,6 +169,9 @@ class USB3LinkLayer(Elaboratable):
 
             # Test and debug.
             ltssm.disable_scrambling             .eq(self.disable_scrambling),
+            ltssm.enable_compliance_scrambling   .eq(compliance_emitter.enable_scrambling),
+            compliance_emitter.enable            .eq(ltssm.emit_compliance_pattern),
+            compliance_emitter.lfps_ping_detected.eq(physical_layer.lfps_ping_detected),
         ]
 
 
@@ -270,6 +280,7 @@ class USB3LinkLayer(Elaboratable):
         m.submodules.stream_arbiter = arbiter = SuperSpeedStreamArbiter()
 
         # Add each of our streams to our arbiter, from highest to lowest priority.
+        arbiter.add_stream(compliance_emitter.source)
         arbiter.add_stream(training_set_source)
         arbiter.add_stream(header_rx.source)
         arbiter.add_stream(transmitter.source)

--- a/luna/gateware/usb/usb3/link/layer.py
+++ b/luna/gateware/usb/usb3/link/layer.py
@@ -7,6 +7,7 @@
 
 from amaranth import *
 
+from ....interface.pipe import TXDeemphMode
 from ...stream          import USBRawSuperSpeedStream, SuperSpeedStreamArbiter, SuperSpeedStreamInterface
 from ..physical.coding  import IDL
 
@@ -113,6 +114,10 @@ class USB3LinkLayer(Elaboratable):
         #
         m.submodules.ltssm = ltssm = LTSSMController(ss_clock_frequency=self._clock_frequency)
 
+        tx_deemph = Mux(compliance_emitter.disable_deemph,
+                        TXDeemphMode.DEEMPH_NONE,
+                        TXDeemphMode.DEEMPH_3P5DB)
+
         m.d.comb += [
             ltssm.phy_ready                      .eq(physical_layer.ready),
 
@@ -126,6 +131,7 @@ class USB3LinkLayer(Elaboratable):
             ltssm.no_link_partner_detected       .eq(physical_layer.no_link_partner_detected),
 
             # Pass down our link controls to the physical layer.
+            physical_layer.tx_deemph             .eq(tx_deemph),
             physical_layer.tx_electrical_idle    .eq(ltssm.tx_electrical_idle),
             physical_layer.tx_ones_zeros         .eq(compliance_emitter.tx_ones_zeros),
             physical_layer.engage_terminations   .eq(ltssm.engage_terminations),

--- a/luna/gateware/usb/usb3/link/layer.py
+++ b/luna/gateware/usb/usb3/link/layer.py
@@ -127,6 +127,7 @@ class USB3LinkLayer(Elaboratable):
 
             # Pass down our link controls to the physical layer.
             physical_layer.tx_electrical_idle    .eq(ltssm.tx_electrical_idle),
+            physical_layer.tx_ones_zeros         .eq(compliance_emitter.tx_ones_zeros),
             physical_layer.engage_terminations   .eq(ltssm.engage_terminations),
             physical_layer.invert_rx_polarity    .eq(ltssm.invert_rx_polarity),
             physical_layer.train_equalizer       .eq(ltssm.train_equalizer),

--- a/luna/gateware/usb/usb3/link/ltssm.py
+++ b/luna/gateware/usb/usb3/link/ltssm.py
@@ -11,6 +11,7 @@
 #
 
 import math
+import os
 
 from amaranth import *
 from amaranth.lib.coding import Encoder
@@ -117,6 +118,7 @@ class LTSSMController(Elaboratable):
         # Loopback & compliance.
         self.act_as_loopback           = Signal()
         self.emit_compliance_pattern   = Signal()
+        self.enable_compliance_scrambling = Signal()
 
 
 
@@ -687,13 +689,19 @@ class LTSSMController(Elaboratable):
             with m.State("Compliance"):
                 handle_warm_resets()
 
-                # We don't currently handle Compliance properly. In this case, this message refers
-                # to the Compliance state, but this also makes us non-compliant, so this statement
-                # has an especially appropriate double meaning.
+                # According to the spec, if we reach this state then we should stay in it and
+                # emit appropriate test patterns.
                 #
-                # We'll throw our hands up in despair and re-try link training.
-                # Maybe this time it'll work.
-                transition_to_state("Rx.Detect.Reset")
+                # Until link training is more reliable, make that behavior optional based on an env var.
+                if os.getenv('LUNA_COMPLIANCE'):
+                    m.d.comb += [
+                        self.emit_compliance_pattern.eq(1),
+                        self.enable_scrambling.eq(self.enable_compliance_scrambling),
+                    ]
+                else:
+                    # We'll throw our hands up in despair and re-try link training.
+                    # Maybe this time it'll work.
+                    transition_to_state("Rx.Detect.Reset")
 
 
             # Loopback -- during the link bringup, our link partner requested that we go into

--- a/luna/gateware/usb/usb3/physical/layer.py
+++ b/luna/gateware/usb/usb3/physical/layer.py
@@ -52,6 +52,7 @@ class USB3PhysicalLayer(Elaboratable):
         self.ready                      = Signal()
         self.engage_terminations        = Signal()
         self.tx_electrical_idle         = Signal()
+        self.tx_ones_zeros              = Signal()
         self.invert_rx_polarity         = Signal()
         self.train_equalizer            = Signal()
         self.vbus_present               = Signal()
@@ -111,6 +112,7 @@ class USB3PhysicalLayer(Elaboratable):
             phy.tx_swing                .eq(0),
             phy.tx_margin               .eq(0b000),
             phy.tx_deemph               .eq(0b01),
+            phy.tx_ones_zeros           .eq(self.tx_ones_zeros),
 
             # Pass through our remaining control signals directly to the PHY.
             phy.rx_termination          .eq(self.engage_terminations),

--- a/luna/gateware/usb/usb3/physical/layer.py
+++ b/luna/gateware/usb/usb3/physical/layer.py
@@ -9,6 +9,8 @@ import logging
 
 from amaranth import *
 from amaranth.lib.fifo import AsyncFIFOBuffered
+
+from ....interface.pipe import TXDeemphMode
 from ...stream  import USBRawSuperSpeedStream
 
 from .lfps       import LFPSTransceiver
@@ -111,7 +113,7 @@ class USB3PhysicalLayer(Elaboratable):
             # Use default/normal signal thresholds.
             phy.tx_swing                .eq(0),
             phy.tx_margin               .eq(0b000),
-            phy.tx_deemph               .eq(0b01),
+            phy.tx_deemph               .eq(TXDeemphMode.DEEMPH_3P5DB),
             phy.tx_ones_zeros           .eq(self.tx_ones_zeros),
 
             # Pass through our remaining control signals directly to the PHY.

--- a/luna/gateware/usb/usb3/physical/layer.py
+++ b/luna/gateware/usb/usb3/physical/layer.py
@@ -68,6 +68,7 @@ class USB3PhysicalLayer(Elaboratable):
         self.send_lfps_polling          = Signal()
         self.lfps_cycles_sent           = Signal(16)
 
+        self.lfps_ping_detected         = Signal()
         self.lfps_polling_detected      = Signal()
         self.lfps_reset_detected        = Signal()
 
@@ -223,6 +224,7 @@ class USB3PhysicalLayer(Elaboratable):
             lfps.send_polling           .eq(self.send_lfps_polling),
             self.lfps_cycles_sent       .eq(lfps.cycles_sent),
 
+            self.lfps_ping_detected     .eq(lfps.ping_detected),
             self.lfps_polling_detected  .eq(lfps.polling_detected),
             self.lfps_reset_detected    .eq(lfps.reset_detected),
 

--- a/luna/gateware/usb/usb3/physical/layer.py
+++ b/luna/gateware/usb/usb3/physical/layer.py
@@ -53,6 +53,7 @@ class USB3PhysicalLayer(Elaboratable):
         # Physical link state.
         self.ready                      = Signal()
         self.engage_terminations        = Signal()
+        self.tx_deemph                  = Signal(TXDeemphMode)
         self.tx_electrical_idle         = Signal()
         self.tx_ones_zeros              = Signal()
         self.invert_rx_polarity         = Signal()
@@ -113,7 +114,7 @@ class USB3PhysicalLayer(Elaboratable):
             # Use default/normal signal thresholds.
             phy.tx_swing                .eq(0),
             phy.tx_margin               .eq(0b000),
-            phy.tx_deemph               .eq(TXDeemphMode.DEEMPH_3P5DB),
+            phy.tx_deemph               .eq(self.tx_deemph),
             phy.tx_ones_zeros           .eq(self.tx_ones_zeros),
 
             # Pass through our remaining control signals directly to the PHY.

--- a/luna/gateware/usb/usb3/physical/lfps.py
+++ b/luna/gateware/usb/usb3/physical/lfps.py
@@ -70,6 +70,10 @@ _PollingLFPSBurst  = LFPSTiming(t_typ=1.0e-6,  t_min=0.6e-6, t_max=1.4e-6)
 _PollingLFPSRepeat = LFPSTiming(t_typ=10.0e-6, t_min=6.0e-6, t_max=14.0e-6)
 _PollingLFPS       = LFPS(burst=_PollingLFPSBurst, repeat=_PollingLFPSRepeat)
 
+_PingLFPSBurst     = LFPSTiming(t_min=40.0e-9, t_max=160.0e-9)
+_PingLFPSRepeat    = LFPSTiming(t_typ=200e-3, t_min=160e-3, t_max=240.0e-3)
+_PingLFPS          = LFPS(burst=_PingLFPSBurst, repeat=_PingLFPSRepeat)
+
 _ResetLFPSBurst    = LFPSTiming(t_typ=100.0e-3, t_min=80.0e-3,  t_max=120.0e-3)
 _ResetLFPS         = LFPS(burst=_ResetLFPSBurst)
 
@@ -319,6 +323,7 @@ class LFPSTransceiver(Elaboratable):
 
         # LFPS burst reception
         self.polling_detected      = Signal() # o
+        self.ping_detected         = Signal() # o
         self.reset_detected        = Signal() # o
 
 
@@ -332,6 +337,12 @@ class LFPSTransceiver(Elaboratable):
         m.d.comb += [
             polling_detector.signaling_received .eq(self.signaling_received),
             self.polling_detected               .eq(polling_detector.detect)
+        ]
+
+        m.submodules.ping_detector = ping_detector = LFPSDetector(_PingLFPS, self._clock_frequency)
+        m.d.comb += [
+            ping_detector.signaling_received .eq(self.signaling_received),
+            self.ping_detected               .eq(ping_detector.detect)
         ]
 
         m.submodules.reset_detector = reset_detector = LFPSDetector(_ResetLFPS, self._clock_frequency)


### PR DESCRIPTION
This implements "compliance mode" (per USB3.x Specification; 7.5.5) which generates test patterns for testing physical-layer electrical compliance.

Entry into compliance mode happens during enumeration when a receiver is detected but detection of Polling.LFPS times out. Previously, we would restart enumeration in this case. This behaviour has been kept by default until enumeration is a bit more stable, and entry into compliance mode can be enabled by setting an env. var `LUNA_COMPLIANCE` at build time.

A new module is added to generate the 9 different test patterns and Ping.LFPS detection has been added to advance through the sequence of patterns.

Support for bypassing 8b10b encoding and transmitting a slow square-wave of 1s and 0s has been added to the pipe interface, and support for TX de-emphasis has been added to the ECP5 PHY, each required for some of the test patterns.

Finally some optimisation has been done on TX amplitude and de-emphasis settings to get the output meeting specification and to improve the eye-diagram in testing, more detail on that here: https://github.com/greatscottgadgets/lab-notes/tree/main/project-reports/2026-05-09-luna-superspeed-improvements